### PR TITLE
Align tests with project test best practices

### DIFF
--- a/src/game/model/card/deck.ts
+++ b/src/game/model/card/deck.ts
@@ -14,11 +14,17 @@ export class Deck<T extends Card = Card> {
     return this.cards;
   }
 
-  /** Shuffles the cards in the deck. */
-  public shuffle(): void {
+  /**
+   * Shuffles the cards in the deck.
+   *
+   * @param random Source of randomness returning a value in [0, 1). Defaults
+   *   to Math.random. Injectable so callers (and tests) can supply a
+   *   deterministic sequence.
+   */
+  public shuffle(random: () => number = Math.random): void {
     // Fisher-Yates shuffle
     for (let i = this.cards.length - 1; i > 0; i--) {
-      const randomIndex = Math.floor(Math.random() * (i + 1));
+      const randomIndex = Math.floor(random() * (i + 1));
       this.swapCards(i, randomIndex);
     }
   }

--- a/src/game/model/game/solitaire_game.ts
+++ b/src/game/model/game/solitaire_game.ts
@@ -6,6 +6,7 @@ import { CardPile } from "../card/card_pile";
 import { Deck } from "../card/deck";
 import {
   PlayingCard,
+  PlayingCardId,
   Suit,
   Type,
   ALL_PLAYING_CARD_IDS,
@@ -36,10 +37,20 @@ export class SolitaireGame extends EventEmitter<GameEvents> {
   private readonly allCardsMap = new Map<string, PlayingCard>();
   private readonly pilesMap = new Map<string, CardPile<PlayingCard>>();
 
-  /** Initializes the piles. */
-  constructor() {
+  /** The card identities used to build the deck for a new game. */
+  private readonly cardIds: ReadonlyArray<PlayingCardId>;
+
+  /**
+   * Initializes the piles.
+   *
+   * @param cardIds The card identities to deal from. Defaults to a full
+   *   standard 52-card deck. Injectable so tests can supply a partial or empty
+   *   set to exercise short-deck handling through the public API.
+   */
+  constructor(cardIds: ReadonlyArray<PlayingCardId> = ALL_PLAYING_CARD_IDS) {
     super();
 
+    this.cardIds = cardIds;
     this.initializePiles();
   }
 
@@ -157,7 +168,7 @@ export class SolitaireGame extends EventEmitter<GameEvents> {
    */
   private createAndShuffleDeck(): PlayingCard[] {
     const tempDeck = new Deck<PlayingCard>();
-    for (const cardId of ALL_PLAYING_CARD_IDS) {
+    for (const cardId of this.cardIds) {
       const playingCard = new PlayingCard();
       playingCard.suite = cardId.suit;
       playingCard.type = cardId.type;
@@ -313,9 +324,10 @@ export class SolitaireGame extends EventEmitter<GameEvents> {
       return false;
     }
 
+    // getPileContainingCard only returns a pile that contains the card, so the
+    // index is always valid here.
     const sourceCards = sourcePile.getCards();
     const cardIndex = sourceCards.indexOf(card);
-    if (cardIndex === -1) return false;
 
     // Get the moving stack (this card + everything on top of it)
     const movingStack = sourceCards.slice(cardIndex);
@@ -428,29 +440,13 @@ export class SolitaireGame extends EventEmitter<GameEvents> {
     }
 
     if (pile.id.startsWith("tableau-")) {
-      // Any face-up card in a tableau is interactable
+      // Any face-up card in a tableau is interactable.
       return card.faceUp;
     }
 
-    if (pile.id === "waste") {
-      // Only the top card of the waste pile is interactable
-      const cards = pile.getCards();
-      return cards.length > 0 && cards[cards.length - 1] === card;
-    }
-
-    if (pile.id.startsWith("foundation-")) {
-      // Only the top card of a foundation pile is interactable
-      const cards = pile.getCards();
-      return cards.length > 0 && cards[cards.length - 1] === card;
-    }
-
-    if (pile.id === "stock") {
-      // Only the top card of the stock pile is interactable
-      const cards = pile.getCards();
-      return cards.length > 0 && cards[cards.length - 1] === card;
-    }
-
-    return false;
+    // The stock, waste, and foundation piles only expose their top card.
+    const cards = pile.getCards();
+    return cards.length > 0 && cards[cards.length - 1] === card;
   }
 
   /**

--- a/src/game/render/scene/board/board_scene.ts
+++ b/src/game/render/scene/board/board_scene.ts
@@ -1,4 +1,3 @@
-import * as Phaser from "phaser";
 import { Scene } from "phaser";
 
 import { ALL_PLAYING_CARD_IDS } from "@/game/model/card/playing_card";
@@ -80,46 +79,6 @@ export class BoardScene extends Scene {
   /** Gets the layout manager helper instance. */
   public getLayoutManager(): BoardLayoutManager {
     return this.layoutManager;
-  }
-
-  /** Getter for highlightGraphics to preserve backward compatibility (e.g. for unit tests). */
-  public get highlightGraphics(): Phaser.GameObjects.Graphics {
-    return this.highlightRenderer.graphics;
-  }
-  public set highlightGraphics(val: Phaser.GameObjects.Graphics) {
-    this.highlightRenderer.graphics = val;
-  }
-
-  /** Getter for hoveredCardVisual to preserve backward compatibility (e.g. for unit tests). */
-  public get hoveredCardVisual(): PlayingCardVisual | null {
-    return this.inputManager.hoveredCardVisual;
-  }
-  public set hoveredCardVisual(val: PlayingCardVisual | null) {
-    this.inputManager.hoveredCardVisual = val;
-  }
-
-  /** Getter for isStockBackgroundHovered to preserve backward compatibility (e.g. for unit tests). */
-  public get isStockBackgroundHovered(): boolean {
-    return this.inputManager.isStockBackgroundHovered;
-  }
-  public set isStockBackgroundHovered(val: boolean) {
-    this.inputManager.isStockBackgroundHovered = val;
-  }
-
-  /** Getter for draggedStack to preserve backward compatibility (e.g. for unit tests). */
-  public get draggedStack(): PlayingCardVisual[] {
-    return this.inputManager.draggedStack;
-  }
-  public set draggedStack(val: PlayingCardVisual[]) {
-    this.inputManager.draggedStack = val;
-  }
-
-  /** Getter for draggedStackOffsets to preserve backward compatibility (e.g. for unit tests). */
-  public get draggedStackOffsets(): { x: number; y: number }[] {
-    return this.inputManager.draggedStackOffsets;
-  }
-  public set draggedStackOffsets(val: { x: number; y: number }[]) {
-    this.inputManager.draggedStackOffsets = val;
   }
 
   /**

--- a/test/game/model/card/card.spec.ts
+++ b/test/game/model/card/card.spec.ts
@@ -1,8 +1,10 @@
-import { Card } from "@/game/model/card/card";
+import { makeCard } from "@test/support/card_builder";
 
 describe("Card", () => {
-  it("can be created", () => {
-    const card: Card = { id: "test-card", faceUp: true };
-    expect(card).toBeDefined();
+  it("exposes the id and faceUp state it was created with", () => {
+    const card = makeCard({ id: "test-card", faceUp: true });
+
+    expect(card.id).toBe("test-card");
+    expect(card.faceUp).toBe(true);
   });
 });

--- a/test/game/model/card/card_pile.spec.ts
+++ b/test/game/model/card/card_pile.spec.ts
@@ -1,17 +1,23 @@
-import { Card } from "@/game/model/card/card";
 import { CardPile } from "@/game/model/card/card_pile";
+import { makeCard } from "@test/support/card_builder";
 
 describe("CardPile", () => {
-  it("should initialize with an empty array of cards and correct id", () => {
+  it("uses the id it was constructed with", () => {
     const pile = new CardPile("test-pile");
+
     expect(pile.id).toBe("test-pile");
+  });
+
+  it("starts empty", () => {
+    const pile = new CardPile("test-pile");
+
     expect(pile.getCards()).toEqual([]);
   });
 
-  it("should add cards and retrieve them", () => {
+  it("keeps added cards in insertion order", () => {
     const pile = new CardPile("test-pile");
-    const card1: Card = { id: "card-1", faceUp: true };
-    const card2: Card = { id: "card-2", faceUp: false };
+    const card1 = makeCard({ id: "card-1", faceUp: true });
+    const card2 = makeCard({ id: "card-2" });
 
     pile.addCard(card1);
     pile.addCard(card2);
@@ -19,10 +25,10 @@ describe("CardPile", () => {
     expect(pile.getCards()).toEqual([card1, card2]);
   });
 
-  it("should remove cards if they exist in the pile", () => {
+  it("removes a card that exists in the pile", () => {
     const pile = new CardPile("test-pile");
-    const card1: Card = { id: "card-1", faceUp: true };
-    const card2: Card = { id: "card-2", faceUp: false };
+    const card1 = makeCard({ id: "card-1" });
+    const card2 = makeCard({ id: "card-2" });
     pile.addCard(card1);
     pile.addCard(card2);
 
@@ -31,24 +37,23 @@ describe("CardPile", () => {
     expect(pile.getCards()).toEqual([card2]);
   });
 
-  it("should do nothing when trying to remove a card not in the pile", () => {
+  it("leaves the pile unchanged when removing a card not in it", () => {
     const pile = new CardPile("test-pile");
-    const card1: Card = { id: "card-1", faceUp: true };
-    const card2: Card = { id: "card-2", faceUp: false };
-    pile.addCard(card2);
+    const present = makeCard({ id: "present" });
+    const absent = makeCard({ id: "absent" });
+    pile.addCard(present);
 
-    pile.removeCard(card1);
+    pile.removeCard(absent);
 
-    expect(pile.getCards()).toEqual([card2]);
+    expect(pile.getCards()).toEqual([present]);
   });
 
-  it("should clear all cards", () => {
+  it("removes all cards when cleared", () => {
     const pile = new CardPile("test-pile");
-    const card1: Card = { id: "card-1", faceUp: true };
-    pile.addCard(card1);
+    pile.addCard(makeCard({ id: "card-1" }));
 
     pile.clear();
 
-    expect(pile.getCards().length).toBe(0);
+    expect(pile.getCards()).toEqual([]);
   });
 });

--- a/test/game/model/card/deck.spec.ts
+++ b/test/game/model/card/deck.spec.ts
@@ -1,5 +1,6 @@
-import { Card } from "@/game/model/card/card";
 import { Deck } from "@/game/model/card/deck";
+import { makeCard } from "@test/support/card_builder";
+import { sequenceRandom } from "@test/support/sequence_random";
 
 describe("Deck", () => {
   let deck: Deck;
@@ -9,26 +10,22 @@ describe("Deck", () => {
   });
 
   it("adds a card", () => {
-    const card: Card = { id: "c1", faceUp: true };
+    const card = makeCard({ id: "c1", faceUp: true });
 
     deck.addCard(card);
 
     expect(deck.getCards()).toEqual([card]);
   });
 
-  it("shuffles the cards", () => {
-    const card1: Card = { id: "c1", faceUp: true };
-    const card2: Card = { id: "c2", faceUp: true };
-    const card3: Card = { id: "c3", faceUp: true };
+  it("shuffles the cards using the provided randomness source", () => {
+    const card1 = makeCard({ id: "c1", faceUp: true });
+    const card2 = makeCard({ id: "c2", faceUp: true });
+    const card3 = makeCard({ id: "c3", faceUp: true });
     deck.addCard(card1);
     deck.addCard(card2);
     deck.addCard(card3);
-    vi.spyOn(Math, "random")
-      .mockReturnValueOnce(0.6)
-      .mockReturnValueOnce(0.2)
-      .mockReturnValueOnce(0.8);
 
-    deck.shuffle();
+    deck.shuffle(sequenceRandom([0.6, 0.2, 0.8]));
 
     expect(deck.getCards()).toEqual([card3, card1, card2]);
   });

--- a/test/game/model/common/event_emitter.spec.ts
+++ b/test/game/model/common/event_emitter.spec.ts
@@ -16,59 +16,62 @@ class TestEmitter extends EventEmitter<MockEvents> {
 }
 
 describe("EventEmitter", () => {
-  it("subscribes and fires events with payload data", () => {
+  it("delivers the emitted payload to a subscriber", () => {
     const emitter = new TestEmitter();
-    const mockCallback = vi.fn();
+    const received: { payload: string }[] = [];
+    emitter.on("test-event", (data) => received.push(data));
 
-    emitter.on("test-event", mockCallback);
     emitter.triggerTest("hello");
 
-    expect(mockCallback).toHaveBeenCalledTimes(1);
-    expect(mockCallback).toHaveBeenCalledWith({ payload: "hello" });
+    expect(received).toEqual([{ payload: "hello" }]);
   });
 
-  it("unsubscribes listeners correctly", () => {
+  it("stops delivering events after a listener is removed", () => {
     const emitter = new TestEmitter();
-    const mockCallback = vi.fn();
+    const received: { payload: string }[] = [];
+    const listener = (data: { payload: string }) => received.push(data);
+    emitter.on("test-event", listener);
+    emitter.off("test-event", listener);
 
-    emitter.on("test-event", mockCallback);
-    emitter.off("test-event", mockCallback);
     emitter.triggerTest("hello");
 
-    expect(mockCallback).not.toHaveBeenCalled();
+    expect(received).toEqual([]);
   });
 
-  it("handles void events correctly", () => {
+  it("delivers void events to subscribers", () => {
     const emitter = new TestEmitter();
-    const mockCallback = vi.fn();
+    let callCount = 0;
+    emitter.on("void-event", () => callCount++);
 
-    emitter.on("void-event", mockCallback);
     emitter.triggerVoid();
 
-    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(callCount).toBe(1);
   });
 
-  it("supports multiple subscribers for the same event", () => {
+  it("delivers the payload to every subscriber of an event", () => {
     const emitter = new TestEmitter();
-    const mockCallback1 = vi.fn();
-    const mockCallback2 = vi.fn();
+    const receivedByFirst: { payload: string }[] = [];
+    const receivedBySecond: { payload: string }[] = [];
+    emitter.on("test-event", (data) => receivedByFirst.push(data));
+    emitter.on("test-event", (data) => receivedBySecond.push(data));
 
-    emitter.on("test-event", mockCallback1);
-    emitter.on("test-event", mockCallback2);
     emitter.triggerTest("multiple");
 
-    expect(mockCallback1).toHaveBeenCalledWith({ payload: "multiple" });
-    expect(mockCallback2).toHaveBeenCalledWith({ payload: "multiple" });
+    expect(receivedByFirst).toEqual([{ payload: "multiple" }]);
+    expect(receivedBySecond).toEqual([{ payload: "multiple" }]);
   });
 
-  it("does not crash when unsubscribing from an event with no listeners", () => {
+  it("does not throw when unsubscribing from an event with no listeners", () => {
     const emitter = new TestEmitter();
-    const mockCallback = vi.fn();
 
-    expect(() => emitter.off("test-event", mockCallback)).not.toThrow();
+    expect(() =>
+      emitter.off("test-event", () => {
+        /* no-op */
+      }),
+    ).not.toThrow();
   });
 
-  it("does not crash when emitting an event with no listeners", () => {
+  it("does not throw when emitting an event with no listeners", () => {
     const emitter = new TestEmitter();
 
     expect(() => emitter.triggerTest("silent")).not.toThrow();

--- a/test/game/model/game/solitaire_game.spec.ts
+++ b/test/game/model/game/solitaire_game.spec.ts
@@ -1,43 +1,11 @@
-import { vi } from "vitest";
 import { SolitaireGame } from "@/game/model/game/solitaire_game";
-import { PlayingCard, Suit, Type } from "@/game/model/card/playing_card";
-import { CardPile } from "@/game/model/card/card_pile";
-
-function setupAlmostWonState(game: SolitaireGame): void {
-  const suitNames = ["spades", "hearts", "diamonds", "clubs"];
-  const typeNames = [
-    "ace",
-    "2",
-    "3",
-    "4",
-    "5",
-    "6",
-    "7",
-    "8",
-    "9",
-    "10",
-    "jack",
-    "queen",
-    "king",
-  ];
-
-  game.stock.clear();
-  game.waste.clear();
-  game.tableaus.forEach((t) => t.clear());
-  game.foundations.forEach((f) => f.clear());
-
-  for (let sIndex = 0; sIndex < 4; sIndex++) {
-    const suitName = suitNames[sIndex];
-    const targetFoundation = game.foundations[sIndex];
-    const maxTypeIndex = sIndex === 3 ? 12 : 13;
-    for (let tIndex = 0; tIndex < maxTypeIndex; tIndex++) {
-      const cardId = `card-${suitName}-${typeNames[tIndex]}`;
-      const card = game.getCardById(cardId)!;
-      card.faceUp = true;
-      targetFoundation.addCard(card);
-    }
-  }
-}
+import { makePlayingCard } from "@test/support/card_builder";
+import {
+  almostWon,
+  CLUB_KING_ID,
+  forceWasteRecycle,
+  relocate,
+} from "@test/support/game_scenarios";
 
 describe("SolitaireGame", () => {
   let game: SolitaireGame;
@@ -46,292 +14,311 @@ describe("SolitaireGame", () => {
     game = new SolitaireGame();
   });
 
-  it("initializes layout piles correctly on constructor", () => {
-    expect(game.stock.id).toBe("stock");
-    expect(game.waste.id).toBe("waste");
-    expect(game.foundations.length).toBe(4);
-    expect(game.tableaus.length).toBe(7);
+  describe("construction", () => {
+    it("creates the stock and waste piles", () => {
+      expect(game.stock.id).toBe("stock");
+      expect(game.waste.id).toBe("waste");
+    });
+
+    it("creates four foundation piles and seven tableau piles", () => {
+      expect(game.foundations.length).toBe(4);
+      expect(game.tableaus.length).toBe(7);
+    });
   });
 
-  it("deals the correct number of cards to piles on startNewGame", () => {
-    game.startNewGame();
+  describe("startNewGame", () => {
+    it("populates the stock with 24 cards", () => {
+      game.startNewGame();
 
-    expect(game.stock.getCards().length).toBe(24);
-    expect(game.waste.getCards().length).toBe(0);
-    expect(game.tableaus.length).toBe(7);
+      expect(game.stock.getCards().length).toBe(24);
+    });
 
-    // Verify stock setup
-    for (let card of game.stock.getCards()) {
-      expect(card.faceUp).toBe(false);
-    }
+    it("deals every stock card face down", () => {
+      game.startNewGame();
 
-    // Verify tableaus setup
-    for (let i = 0; i < 7; i++) {
-      expect(game.tableaus[i].getCards().length).toBe(i + 1);
+      const allFaceDown = game.stock.getCards().every((card) => !card.faceUp);
+      expect(allFaceDown).toBe(true);
+    });
 
-      for (let j = 0; j < i; j++) {
-        expect(game.tableaus[i].getCards()[j].faceUp).toBe(false);
-      }
-      // Last card in pile should always be face up.
-      expect(game.tableaus[i].getCards()[i].faceUp).toBe(true);
-    }
+    it("leaves the waste empty", () => {
+      game.startNewGame();
+
+      expect(game.waste.getCards()).toEqual([]);
+    });
+
+    it("deals an increasing number of cards to each tableau", () => {
+      game.startNewGame();
+
+      const counts = game.tableaus.map((t) => t.getCards().length);
+      expect(counts).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    it("leaves only the top card of each tableau face up", () => {
+      game.startNewGame();
+
+      const faceUpLayout = game.tableaus.map((t) =>
+        t.getCards().map((card) => card.faceUp),
+      );
+      expect(faceUpLayout).toEqual([
+        [true],
+        [false, true],
+        [false, false, true],
+        [false, false, false, true],
+        [false, false, false, false, true],
+        [false, false, false, false, false, true],
+        [false, false, false, false, false, false, true],
+      ]);
+    });
+
+    it("deals nothing when constructed with an empty deck", () => {
+      const shortGame = new SolitaireGame([]);
+
+      shortGame.startNewGame();
+
+      expect(shortGame.stock.getCards()).toEqual([]);
+      expect(shortGame.tableaus.every((t) => t.getCards().length === 0)).toBe(
+        true,
+      );
+    });
   });
 
-  it("draws 3 cards from stock to waste and flips them face up", () => {
-    game.startNewGame();
-    const initialStockCount = game.stock.getCards().length; // 24
-    // Capture the top 3 cards (they will be drawn in order: top first)
-    const top1 = game.stock.getCards()[initialStockCount - 1] as PlayingCard;
-    const top2 = game.stock.getCards()[initialStockCount - 2] as PlayingCard;
-    const top3 = game.stock.getCards()[initialStockCount - 3] as PlayingCard;
+  describe("drawCardsFromStock", () => {
+    it("moves three cards to the waste in draw order", () => {
+      game.startNewGame();
+      const stock = game.stock.getCards();
+      const expectedWaste = [
+        stock[stock.length - 1],
+        stock[stock.length - 2],
+        stock[stock.length - 3],
+      ];
 
-    game.drawCardsFromStock();
+      game.drawCardsFromStock();
 
-    expect(game.stock.getCards().length).toBe(21);
-    expect(game.waste.getCards().length).toBe(3);
-    // Cards are added to waste in draw order: top1 first, top3 last (on top)
-    expect(game.waste.getCards()[0]).toBe(top1);
-    expect(game.waste.getCards()[1]).toBe(top2);
-    expect(game.waste.getCards()[2]).toBe(top3);
-    expect(top1.faceUp).toBe(true);
-    expect(top2.faceUp).toBe(true);
-    expect(top3.faceUp).toBe(true);
+      expect(game.stock.getCards().length).toBe(21);
+      expect(game.waste.getCards()).toEqual(expectedWaste);
+    });
+
+    it("flips the drawn cards face up", () => {
+      game.startNewGame();
+
+      game.drawCardsFromStock();
+
+      const allFaceUp = game.waste.getCards().every((card) => card.faceUp);
+      expect(allFaceUp).toBe(true);
+    });
+
+    it("does nothing when both the stock and waste are empty", () => {
+      const emptyGame = new SolitaireGame();
+
+      emptyGame.drawCardsFromStock();
+
+      expect(emptyGame.stock.getCards()).toEqual([]);
+      expect(emptyGame.waste.getCards()).toEqual([]);
+    });
+
+    it("recycles the waste back into the stock face down when the stock is empty", () => {
+      game.startNewGame();
+      relocate(game, "card-clubs-ace", game.waste);
+      relocate(game, "card-clubs-2", game.waste);
+      game.stock.clear();
+      game.tableaus.forEach((t) => t.clear());
+      game.foundations.forEach((f) => f.clear());
+
+      game.drawCardsFromStock();
+
+      expect(game.waste.getCards()).toEqual([]);
+      expect(game.stock.getCards().length).toBe(2);
+      const allFaceDown = game.stock.getCards().every((card) => !card.faceUp);
+      expect(allFaceDown).toBe(true);
+    });
   });
 
-  it("recycles waste back to stock if stock is empty", () => {
-    game.startNewGame();
-    const card1 = game.getCardById("card-clubs-ace")!;
-    const card2 = game.getCardById("card-clubs-2")!;
-    game.stock.clear();
-    game.waste.clear();
-    game.tableaus.forEach((t) => t.clear());
-    game.foundations.forEach((f) => f.clear());
-
-    card1.faceUp = true;
-    card2.faceUp = true;
-    game.waste.addCard(card1);
-    game.waste.addCard(card2);
-
-    game.drawCardsFromStock();
-
-    expect(game.stock.getCards().length).toBe(2);
-    expect(game.waste.getCards().length).toBe(0);
-    expect(game.stock.getCards()[0].faceUp).toBe(false);
-    expect(game.stock.getCards()[1].faceUp).toBe(false);
-  });
-
-  describe("Card Rules Validation", () => {
-    it("does not move a non-King card to an empty tableau pile", () => {
+  describe("move validation", () => {
+    it("does not move a non-King card onto an empty tableau", () => {
       game.startNewGame();
       game.tableaus[0].clear();
-      const queen = game.getCardById("card-hearts-queen")!;
-      game.getPileContainingCard(queen.id)?.removeCard(queen);
-      queen.faceUp = true;
-      game.tableaus[1].clear();
-      game.tableaus[1].addCard(queen);
+      const queen = relocate(game, "card-hearts-queen", game.tableaus[1]);
 
       const moved = game.moveCardToPile(queen.id, "tableau-0");
 
       expect(moved).toBe(false);
     });
 
-    it("moves a King card to an empty tableau pile", () => {
+    it("moves a King onto an empty tableau", () => {
       game.startNewGame();
       game.tableaus[0].clear();
-      const king = game.getCardById("card-spades-king")!;
-      game.getPileContainingCard(king.id)?.removeCard(king);
-      king.faceUp = true;
-      game.tableaus[1].clear();
-      game.tableaus[1].addCard(king);
+      const king = relocate(game, "card-spades-king", game.tableaus[1]);
 
       const moved = game.moveCardToPile(king.id, "tableau-0");
 
       expect(moved).toBe(true);
-      expect(game.tableaus[0].getCards()[0]).toBe(king);
+      expect(game.tableaus[0].getCards()).toEqual([king]);
     });
 
-    it("does not move a card onto tableau if color is the same", () => {
+    it("does not move a card onto a tableau card of the same color", () => {
       game.startNewGame();
-      const redEight = game.getCardById("card-diamonds-8")!;
-      const redSeven = game.getCardById("card-hearts-7")!;
-      game.getPileContainingCard(redEight.id)?.removeCard(redEight);
-      game.getPileContainingCard(redSeven.id)?.removeCard(redSeven);
-      redEight.faceUp = true;
-      redSeven.faceUp = true;
-      game.tableaus[0].clear();
-      game.tableaus[0].addCard(redEight);
-      game.tableaus[1].clear();
-      game.tableaus[1].addCard(redSeven);
+      relocate(game, "card-diamonds-8", game.tableaus[0]);
+      const redSeven = relocate(game, "card-hearts-7", game.tableaus[1]);
 
       const moved = game.moveCardToPile(redSeven.id, "tableau-0");
 
       expect(moved).toBe(false);
     });
 
-    it("moves a card onto tableau if rank is descending and color alternates", () => {
+    it("moves a card onto a tableau card of descending rank and alternating color", () => {
       game.startNewGame();
-      const redEight = game.getCardById("card-diamonds-8")!;
-      const blackSeven = game.getCardById("card-spades-7")!;
-      const redSeven = game.getCardById("card-hearts-7")!;
-      game.getPileContainingCard(redEight.id)?.removeCard(redEight);
-      game.getPileContainingCard(blackSeven.id)?.removeCard(blackSeven);
-      game.getPileContainingCard(redSeven.id)?.removeCard(redSeven);
-      redEight.faceUp = true;
-      blackSeven.faceUp = true;
-      redSeven.faceUp = true;
       game.tableaus[0].clear();
-      game.tableaus[0].addCard(redEight);
       game.tableaus[1].clear();
-      game.tableaus[1].addCard(blackSeven);
-      game.tableaus[1].addCard(redSeven);
+      relocate(game, "card-diamonds-8", game.tableaus[0]);
+      const blackSeven = relocate(game, "card-spades-7", game.tableaus[1]);
+      const redSeven = relocate(game, "card-hearts-7", game.tableaus[1]);
 
       const moved = game.moveCardToPile(blackSeven.id, "tableau-0");
 
       expect(moved).toBe(true);
-      expect(game.tableaus[0].getCards()).toContain(blackSeven);
-      expect(game.tableaus[0].getCards()).toContain(redSeven);
+      expect(game.tableaus[0].getCards()).toEqual([
+        game.getCardById("card-diamonds-8"),
+        blackSeven,
+        redSeven,
+      ]);
     });
 
-    it("does not move a non-Ace card to an empty foundation", () => {
+    it("does not move a non-Ace onto an empty foundation", () => {
       game.startNewGame();
-      const clubTwo = game.getCardById("card-clubs-2")!;
-      game.getPileContainingCard(clubTwo.id)?.removeCard(clubTwo);
-      clubTwo.faceUp = true;
-      game.tableaus[0].clear();
-      game.tableaus[0].addCard(clubTwo);
+      const clubTwo = relocate(game, "card-clubs-2", game.tableaus[0]);
 
       const moved = game.moveCardToPile(clubTwo.id, "foundation-0");
 
       expect(moved).toBe(false);
     });
 
-    it("moves an Ace card to an empty foundation", () => {
+    it("moves an Ace onto an empty foundation", () => {
       game.startNewGame();
-      const clubAce = game.getCardById("card-clubs-ace")!;
-      game.getPileContainingCard(clubAce.id)?.removeCard(clubAce);
-      clubAce.faceUp = true;
-      game.tableaus[1].clear();
-      game.tableaus[1].addCard(clubAce);
+      const clubAce = relocate(game, "card-clubs-ace", game.tableaus[1]);
 
       const moved = game.moveCardToPile(clubAce.id, "foundation-0");
 
       expect(moved).toBe(true);
     });
 
-    it("moves a card to foundation if rank increases sequentially and suit matches", () => {
+    it("moves a card onto a foundation of ascending rank and matching suit", () => {
       game.startNewGame();
-      const clubAce = game.getCardById("card-clubs-ace")!;
-      const clubTwo = game.getCardById("card-clubs-2")!;
-      game.getPileContainingCard(clubAce.id)?.removeCard(clubAce);
-      game.getPileContainingCard(clubTwo.id)?.removeCard(clubTwo);
-      clubAce.faceUp = true;
-      clubTwo.faceUp = true;
-      game.foundations[0].clear();
-      game.foundations[0].addCard(clubAce);
-      game.tableaus[0].clear();
-      game.tableaus[0].addCard(clubTwo);
+      relocate(game, "card-clubs-ace", game.foundations[0]);
+      const clubTwo = relocate(game, "card-clubs-2", game.tableaus[0]);
 
       const moved = game.moveCardToPile(clubTwo.id, "foundation-0");
 
       expect(moved).toBe(true);
     });
+
+    it("does not move a stack of more than one card onto a foundation", () => {
+      game.startNewGame();
+      game.tableaus[0].clear();
+      const ace = relocate(game, "card-clubs-ace", game.tableaus[0]);
+      relocate(game, "card-clubs-2", game.tableaus[0]);
+
+      const moved = game.moveCardToPile(ace.id, "foundation-0");
+
+      expect(moved).toBe(false);
+    });
   });
 
-  describe("Additional Game Logic Coverage", () => {
-    it("does nothing when drawCard is called and both stock and waste are empty", () => {
-      const emptyGame = new SolitaireGame();
-
-      emptyGame.drawCardsFromStock();
-
-      expect(emptyGame.stock.getCards().length).toBe(0);
-      expect(emptyGame.waste.getCards().length).toBe(0);
-    });
-
-    it("returns undefined in findPileContainingCard if card is not in any pile", () => {
-      game.startNewGame();
-      const card = game.getCardById("card-clubs-ace")!;
-      game.getPileContainingCard(card.id)?.removeCard(card);
-      expect(game.getPileContainingCard(card.id)).toBeUndefined();
-    });
-
-    it("returns false when trying to move an invalid card ID", () => {
+  describe("rejected moves", () => {
+    it("rejects an unknown card id", () => {
       game.startNewGame();
 
-      const moved = game.moveCardToPile("invalid-card-id", "tableau-0");
-
-      expect(moved).toBe(false);
+      expect(game.moveCardToPile("invalid-card-id", "tableau-0")).toBe(false);
     });
 
-    it("returns false when trying to move to an invalid target pile ID", () => {
+    it("rejects an unknown target pile id", () => {
       game.startNewGame();
       const cardId = game.stock.getCards()[0].id;
 
-      const moved = game.moveCardToPile(cardId, "invalid-pile-id");
-
-      expect(moved).toBe(false);
+      expect(game.moveCardToPile(cardId, "invalid-pile-id")).toBe(false);
     });
 
-    it("returns false when trying to move a card to its current pile", () => {
+    it("rejects a move to the card's current pile", () => {
       game.startNewGame();
       const cardId = game.stock.getCards()[0].id;
-      const sourcePile = game.getPileContainingCard(cardId);
+      const sourcePile = game.getPileContainingCard(cardId)!;
 
-      const moved = game.moveCardToPile(cardId, sourcePile!.id);
-
-      expect(moved).toBe(false);
+      expect(game.moveCardToPile(cardId, sourcePile.id)).toBe(false);
     });
 
-    it("returns false in moveCard if card is face down", () => {
+    it("rejects moving a face-down card", () => {
       game.startNewGame();
-      // Tableau 1 has 2 cards, the bottom one is face down
       const faceDownCard = game.tableaus[1].getCards()[0];
-      expect(faceDownCard.faceUp).toBe(false);
+
       expect(game.moveCardToPile(faceDownCard.id, "tableau-0")).toBe(false);
     });
 
-    it("auto-flips the new top card of the tableau pile if it is face-down after a move", () => {
+    it("rejects the stock pile as a target", () => {
       game.startNewGame();
+      const cardId = game.tableaus[0].getCards()[0].id;
 
-      const king = game.getCardById("card-spades-king")!;
-      const bottomCard = game.getCardById("card-clubs-jack")!;
-      const topCard = game.getCardById("card-hearts-queen")!;
+      expect(game.moveCardToPile(cardId, "stock")).toBe(false);
+    });
 
-      game.getPileContainingCard(king.id)?.removeCard(king);
-      game.getPileContainingCard(bottomCard.id)?.removeCard(bottomCard);
-      game.getPileContainingCard(topCard.id)?.removeCard(topCard);
+    it("rejects the waste pile as a target", () => {
+      game.startNewGame();
+      const cardId = game.tableaus[0].getCards()[0].id;
 
-      king.faceUp = true;
-      bottomCard.faceUp = false;
-      topCard.faceUp = true;
+      expect(game.moveCardToPile(cardId, "waste")).toBe(false);
+    });
+  });
 
+  describe("moving stacks", () => {
+    it("auto-flips the newly exposed tableau card after a move", () => {
+      game.startNewGame();
       game.tableaus[0].clear();
-      game.tableaus[0].addCard(king);
-
+      relocate(game, "card-spades-king", game.tableaus[0]);
       game.tableaus[1].clear();
-      game.tableaus[1].addCard(bottomCard);
-      game.tableaus[1].addCard(topCard);
+      const bottomCard = relocate(
+        game,
+        "card-clubs-jack",
+        game.tableaus[1],
+        false,
+      );
+      const topCard = relocate(game, "card-hearts-queen", game.tableaus[1]);
 
       const moved = game.moveCardToPile(topCard.id, "tableau-0");
-      expect(moved).toBe(true);
 
+      expect(moved).toBe(true);
       expect(bottomCard.faceUp).toBe(true);
     });
 
-    it("does not crash when flipping a non-existent card ID", () => {
+    it("does not re-flip a tableau card that is already face up after a move", () => {
+      game.startNewGame();
+      game.tableaus[0].clear();
+      relocate(game, "card-clubs-king", game.tableaus[0]);
+      game.tableaus[1].clear();
+      relocate(game, "card-spades-king", game.tableaus[1]);
+      const movingQueen = relocate(game, "card-hearts-queen", game.tableaus[1]);
+      const flippedEvents: { cardId: string }[] = [];
+      game.on("card-flipped", (payload) => flippedEvents.push(payload));
+
+      const moved = game.moveCardToPile(movingQueen.id, "tableau-0");
+
+      expect(moved).toBe(true);
+      expect(flippedEvents).toEqual([]);
+    });
+  });
+
+  describe("flipCard", () => {
+    it("does not throw for an unknown card id", () => {
       expect(() => game.flipCard("non-existent-card", true)).not.toThrow();
     });
 
-    it("does not flip card if it is not in a tableau pile", () => {
+    it("does not flip a card that is not in a tableau pile", () => {
       game.startNewGame();
       const stockCard = game.stock.getCards()[0];
-      const initialFaceUp = stockCard.faceUp;
 
-      game.flipCard(stockCard.id, !initialFaceUp);
+      game.flipCard(stockCard.id, true);
 
-      expect(stockCard.faceUp).toBe(initialFaceUp);
+      expect(stockCard.faceUp).toBe(false);
     });
 
-    it("does not flip card if it is in a tableau pile but not the top card", () => {
+    it("does not flip a tableau card that is not the top card", () => {
       game.startNewGame();
       const bottomCard = game.tableaus[1].getCards()[0];
 
@@ -348,479 +335,292 @@ describe("SolitaireGame", () => {
 
       expect(topCard.faceUp).toBe(false);
     });
+  });
 
-    it("validates foundation rules: cannot move multiple cards at once to foundation", () => {
+  describe("win condition", () => {
+    it("emits game-won once all 52 cards reach the foundations", () => {
       game.startNewGame();
-      const card1 = game.getCardById("card-clubs-ace")!;
-      const card2 = game.getCardById("card-clubs-2")!;
-      game.getPileContainingCard(card1.id)?.removeCard(card1);
-      game.getPileContainingCard(card2.id)?.removeCard(card2);
-      card1.faceUp = true;
-      card2.faceUp = true;
-
-      game.tableaus[0].clear();
-      game.tableaus[0].addCard(card1);
-      game.tableaus[0].addCard(card2);
-
-      expect(game.moveCardToPile(card1.id, "foundation-0")).toBe(false);
-    });
-
-    it("returns false when trying to move cards to stock or waste as target", () => {
-      game.startNewGame();
-      const cardId = game.tableaus[0].getCards()[0].id;
-
-      expect(game.moveCardToPile(cardId, "stock")).toBe(false);
-      expect(game.moveCardToPile(cardId, "waste")).toBe(false);
-    });
-
-    it("emits game-won when all 52 cards are in the foundation piles", () => {
-      game.startNewGame();
-      setupAlmostWonState(game);
-
-      const kingOfClubs = game.getCardById("card-clubs-king")!;
+      almostWon(game);
+      const kingOfClubs = game.getCardById(CLUB_KING_ID)!;
       kingOfClubs.faceUp = true;
       game.tableaus[0].addCard(kingOfClubs);
-
-      const wonCallback = vi.fn();
-      game.on("game-won", wonCallback);
+      let wonCount = 0;
+      game.on("game-won", () => wonCount++);
 
       const moved = game.moveCardToPile(kingOfClubs.id, "foundation-3");
 
       expect(moved).toBe(true);
-      expect(wonCallback).toHaveBeenCalledTimes(1);
-    });
-
-    it("returns false in moveCard if card is not in the source pile returned by getPileContainingCard (cardIndex === -1)", () => {
-      game.startNewGame();
-      const card = game.stock.getCards()[0];
-      card.faceUp = true;
-      // Stub getPileContainingCard to return tableau-0, which does not contain the stock card
-      vi.spyOn(game, "getPileContainingCard").mockReturnValue(game.tableaus[0]);
-      expect(game.moveCardToPile(card.id, "tableau-1")).toBe(false);
-    });
-
-    it("does not emit card-flipped if the remaining top card is already face-up after a move", () => {
-      game.startNewGame();
-
-      const targetKing = game.getCardById("card-clubs-king")!;
-      const remainingKing = game.getCardById("card-spades-king")!;
-      const movingQueen = game.getCardById("card-hearts-queen")!;
-
-      game.getPileContainingCard(targetKing.id)?.removeCard(targetKing);
-      game.getPileContainingCard(remainingKing.id)?.removeCard(remainingKing);
-      game.getPileContainingCard(movingQueen.id)?.removeCard(movingQueen);
-
-      targetKing.faceUp = true;
-      remainingKing.faceUp = true;
-      movingQueen.faceUp = true;
-
-      game.tableaus[0].clear();
-      game.tableaus[0].addCard(targetKing);
-
-      game.tableaus[1].clear();
-      game.tableaus[1].addCard(remainingKing);
-      game.tableaus[1].addCard(movingQueen);
-
-      const flippedSpy = vi.fn();
-      game.on("card-flipped", flippedSpy);
-
-      const moved = game.moveCardToPile(movingQueen.id, "tableau-0");
-      expect(moved).toBe(true);
-      expect(flippedSpy).not.toHaveBeenCalled();
-    });
-
-    it("handles empty or insufficient deck gracefully during dealTableaus and populateStock", () => {
-      // Return an array containing undefined values to test both dealTableaus and populateStock 'if (card)' false conditions
-      const mockDeck = Array(35).fill(undefined) as unknown as PlayingCard[];
-      vi.spyOn(
-        game as unknown as { createAndShuffleDeck: () => PlayingCard[] },
-        "createAndShuffleDeck",
-      ).mockReturnValue(mockDeck);
-
-      expect(() => game.startNewGame()).not.toThrow();
-      expect(game.stock.getCards().length).toBe(0);
-      game.tableaus.forEach((t) => {
-        expect(t.getCards().length).toBe(0);
-      });
+      expect(wonCount).toBe(1);
     });
   });
 
   describe("isCardInteractable", () => {
-    it("handles tableau piles: face-up card is interactable", () => {
+    it("treats a face-up tableau card as interactable", () => {
       game.startNewGame();
       const card = game.tableaus[0].getCards()[0];
       card.faceUp = true;
 
-      const interactable = game.isCardInteractable(card);
-
-      expect(interactable).toBe(true);
+      expect(game.isCardInteractable(card)).toBe(true);
     });
 
-    it("handles tableau piles: face-down card is not interactable", () => {
+    it("treats a face-down tableau card as not interactable", () => {
       game.startNewGame();
       const card = game.tableaus[0].getCards()[0];
       card.faceUp = false;
 
-      const interactable = game.isCardInteractable(card);
-
-      expect(interactable).toBe(false);
+      expect(game.isCardInteractable(card)).toBe(false);
     });
 
-    it("handles waste pile: top card is interactable", () => {
+    it("treats the top waste card as interactable", () => {
       game.startNewGame();
-      const card1 = game.getCardById("card-spades-2")!;
-      const card2 = game.getCardById("card-hearts-king")!;
-      game.getPileContainingCard(card1.id)?.removeCard(card1);
-      game.getPileContainingCard(card2.id)?.removeCard(card2);
-      game.waste.clear();
-      card1.faceUp = true;
-      card2.faceUp = true;
-      game.waste.addCard(card1);
-      game.waste.addCard(card2);
+      relocate(game, "card-spades-2", game.waste);
+      const top = relocate(game, "card-hearts-king", game.waste);
 
-      const interactable = game.isCardInteractable(card2);
-
-      expect(interactable).toBe(true);
+      expect(game.isCardInteractable(top)).toBe(true);
     });
 
-    it("handles waste pile: non-top card is not interactable", () => {
+    it("treats a non-top waste card as not interactable", () => {
       game.startNewGame();
-      const card1 = game.getCardById("card-spades-2")!;
-      const card2 = game.getCardById("card-hearts-king")!;
-      game.getPileContainingCard(card1.id)?.removeCard(card1);
-      game.getPileContainingCard(card2.id)?.removeCard(card2);
-      game.waste.clear();
-      card1.faceUp = true;
-      card2.faceUp = true;
-      game.waste.addCard(card1);
-      game.waste.addCard(card2);
+      const bottom = relocate(game, "card-spades-2", game.waste);
+      relocate(game, "card-hearts-king", game.waste);
 
-      const interactable = game.isCardInteractable(card1);
-
-      expect(interactable).toBe(false);
+      expect(game.isCardInteractable(bottom)).toBe(false);
     });
 
-    it("handles foundation piles: top card is interactable", () => {
+    it("treats the top foundation card as interactable", () => {
       game.startNewGame();
-      const card1 = game.getCardById("card-diamonds-ace")!;
-      const card2 = game.getCardById("card-diamonds-2")!;
-      game.getPileContainingCard(card1.id)?.removeCard(card1);
-      game.getPileContainingCard(card2.id)?.removeCard(card2);
-      game.foundations[0].clear();
-      card1.faceUp = true;
-      card2.faceUp = true;
-      game.foundations[0].addCard(card1);
-      game.foundations[0].addCard(card2);
+      relocate(game, "card-diamonds-ace", game.foundations[0]);
+      const top = relocate(game, "card-diamonds-2", game.foundations[0]);
 
-      const interactable = game.isCardInteractable(card2);
-
-      expect(interactable).toBe(true);
+      expect(game.isCardInteractable(top)).toBe(true);
     });
 
-    it("handles foundation piles: non-top card is not interactable", () => {
+    it("treats a non-top foundation card as not interactable", () => {
       game.startNewGame();
-      const card1 = game.getCardById("card-diamonds-ace")!;
-      const card2 = game.getCardById("card-diamonds-2")!;
-      game.getPileContainingCard(card1.id)?.removeCard(card1);
-      game.getPileContainingCard(card2.id)?.removeCard(card2);
-      game.foundations[0].clear();
-      card1.faceUp = true;
-      card2.faceUp = true;
-      game.foundations[0].addCard(card1);
-      game.foundations[0].addCard(card2);
+      const bottom = relocate(game, "card-diamonds-ace", game.foundations[0]);
+      relocate(game, "card-diamonds-2", game.foundations[0]);
 
-      const interactable = game.isCardInteractable(card1);
-
-      expect(interactable).toBe(false);
+      expect(game.isCardInteractable(bottom)).toBe(false);
     });
 
-    it("handles stock pile: top card is interactable", () => {
+    it("treats the top stock card as interactable", () => {
       game.startNewGame();
-      const cards = game.stock.getCards();
-      const topCard = cards[cards.length - 1];
+      const stock = game.stock.getCards();
 
-      const interactable = game.isCardInteractable(topCard);
-
-      expect(interactable).toBe(true);
+      expect(game.isCardInteractable(stock[stock.length - 1])).toBe(true);
     });
 
-    it("handles stock pile: non-top card is not interactable", () => {
+    it("treats a non-top stock card as not interactable", () => {
       game.startNewGame();
-      const cards = game.stock.getCards();
-      const nonTopCard = cards[0];
 
-      const interactable = game.isCardInteractable(nonTopCard);
-
-      expect(interactable).toBe(false);
+      expect(game.isCardInteractable(game.stock.getCards()[0])).toBe(false);
     });
 
-    it("returns false if card is not in any pile", () => {
-      const card = new PlayingCard();
-      card.id = "ghost-card";
+    it("treats a card that is in no pile as not interactable", () => {
+      const ghost = makePlayingCard({ id: "ghost-card" });
 
-      const interactable = game.isCardInteractable(card);
-
-      expect(interactable).toBe(false);
-    });
-
-    it("returns false if card is in an unknown pile type", () => {
-      game.startNewGame();
-      const card = game.getCardById("card-clubs-ace")!;
-      const mockPile = {
-        id: "unknown-pile-id",
-        getCards: () => [card],
-      } as unknown as CardPile;
-      vi.spyOn(game, "getPileContainingCard").mockReturnValue(mockPile);
-
-      const interactable = game.isCardInteractable(card);
-
-      expect(interactable).toBe(false);
+      expect(game.isCardInteractable(ghost)).toBe(false);
     });
   });
 
   describe("isCardDraggable", () => {
-    it("handles stock pile: top card is not draggable", () => {
+    it("treats the top stock card as not draggable", () => {
       game.startNewGame();
-      const cards = game.stock.getCards();
-      const topCard = cards[cards.length - 1];
+      const stock = game.stock.getCards();
 
-      const draggable = game.isCardDraggable(topCard);
-
-      expect(draggable).toBe(false);
+      expect(game.isCardDraggable(stock[stock.length - 1])).toBe(false);
     });
 
-    it("handles tableau piles: face-up card is draggable", () => {
+    it("treats a face-up tableau card as draggable", () => {
       game.startNewGame();
       const card = game.tableaus[0].getCards()[0];
       card.faceUp = true;
 
-      const draggable = game.isCardDraggable(card);
-
-      expect(draggable).toBe(true);
+      expect(game.isCardDraggable(card)).toBe(true);
     });
 
-    it("handles tableau piles: face-down card is not draggable", () => {
+    it("treats a face-down tableau card as not draggable", () => {
       game.startNewGame();
       const card = game.tableaus[0].getCards()[0];
       card.faceUp = false;
 
-      const draggable = game.isCardDraggable(card);
-
-      expect(draggable).toBe(false);
+      expect(game.isCardDraggable(card)).toBe(false);
     });
 
-    it("handles waste pile: top card is draggable", () => {
+    it("treats the top waste card as draggable", () => {
       game.startNewGame();
-      const card1 = game.getCardById("card-spades-2")!;
-      const card2 = game.getCardById("card-hearts-king")!;
-      game.getPileContainingCard(card1.id)?.removeCard(card1);
-      game.getPileContainingCard(card2.id)?.removeCard(card2);
-      game.waste.clear();
-      card1.faceUp = true;
-      card2.faceUp = true;
-      game.waste.addCard(card1);
-      game.waste.addCard(card2);
+      relocate(game, "card-spades-2", game.waste);
+      const top = relocate(game, "card-hearts-king", game.waste);
 
-      const draggable = game.isCardDraggable(card2);
-
-      expect(draggable).toBe(true);
+      expect(game.isCardDraggable(top)).toBe(true);
     });
 
-    it("handles foundation piles: top card is draggable", () => {
+    it("treats the top foundation card as draggable", () => {
       game.startNewGame();
-      const card1 = game.getCardById("card-diamonds-ace")!;
-      const card2 = game.getCardById("card-diamonds-2")!;
-      game.getPileContainingCard(card1.id)?.removeCard(card1);
-      game.getPileContainingCard(card2.id)?.removeCard(card2);
-      game.foundations[0].clear();
-      card1.faceUp = true;
-      card2.faceUp = true;
-      game.foundations[0].addCard(card1);
-      game.foundations[0].addCard(card2);
+      relocate(game, "card-diamonds-ace", game.foundations[0]);
+      const top = relocate(game, "card-diamonds-2", game.foundations[0]);
 
-      const draggable = game.isCardDraggable(card2);
-
-      expect(draggable).toBe(true);
+      expect(game.isCardDraggable(top)).toBe(true);
     });
 
-    it("returns false if card is not in any pile", () => {
-      const card = new PlayingCard();
-      card.id = "ghost-card";
+    it("treats a card that is in no pile as not draggable", () => {
+      const ghost = makePlayingCard({ id: "ghost-card" });
 
-      const draggable = game.isCardDraggable(card);
-
-      expect(draggable).toBe(false);
+      expect(game.isCardDraggable(ghost)).toBe(false);
     });
   });
 
-  describe("Scoring, Moves, and Game Options", () => {
-    it("starts a new game with zeroed score, moves, and default options", () => {
+  describe("scoring", () => {
+    it("starts a new game with a zeroed score and move count", () => {
       game.startNewGame();
+
       expect(game.state.score).toBe(0);
       expect(game.state.moves).toBe(0);
+    });
+
+    it("scores +5 and counts a move when moving from waste to tableau", () => {
+      game.startNewGame();
+      game.tableaus[0].clear();
+      relocate(game, "card-spades-king", game.tableaus[0]);
+      const queen = relocate(game, "card-hearts-queen", game.waste);
+
+      const moved = game.moveCardToPile(queen.id, "tableau-0");
+
+      expect(moved).toBe(true);
+      expect(game.state.score).toBe(5);
+      expect(game.state.moves).toBe(1);
+    });
+
+    it("scores +10 when moving from waste to foundation", () => {
+      game.startNewGame();
+      const ace = relocate(game, "card-spades-ace", game.waste);
+
+      const moved = game.moveCardToPile(ace.id, "foundation-0");
+
+      expect(moved).toBe(true);
+      expect(game.state.score).toBe(10);
+    });
+
+    it("scores +10 when moving from tableau to foundation", () => {
+      game.startNewGame();
+      game.tableaus[0].clear();
+      const ace = relocate(game, "card-hearts-ace", game.tableaus[0]);
+
+      const moved = game.moveCardToPile(ace.id, "foundation-1");
+
+      expect(moved).toBe(true);
+      expect(game.state.score).toBe(10);
+    });
+
+    it("scores -15 when moving from foundation to tableau", () => {
+      game.startNewGame();
+      game.foundations[0].clear();
+      const ace = relocate(game, "card-clubs-ace", game.foundations[0]);
+      game.tableaus[0].clear();
+      relocate(game, "card-diamonds-2", game.tableaus[0]);
+      game.state.score = 20;
+
+      const moved = game.moveCardToPile(ace.id, "tableau-0");
+
+      expect(moved).toBe(true);
+      expect(game.state.score).toBe(5);
+    });
+
+    it("adds a +5 flip bonus on top of the move score when a tableau card is exposed", () => {
+      game.startNewGame();
+      game.tableaus[0].clear();
+      relocate(game, "card-spades-10", game.tableaus[0], false);
+      const ace = relocate(game, "card-hearts-ace", game.tableaus[0]);
+      game.foundations[0].clear();
+
+      const moved = game.moveCardToPile(ace.id, "foundation-0");
+
+      expect(moved).toBe(true);
+      expect(game.state.score).toBe(15);
+    });
+  });
+
+  describe("recycle penalties", () => {
+    it("does not penalize the first waste recycle in Draw 1 mode", () => {
+      game.startNewGame();
+      game.setDrawCount(1);
+      const king = game.getCardById(CLUB_KING_ID)!;
+      game.state.score = 200;
+
+      forceWasteRecycle(game, king);
+
+      expect(game.state.score).toBe(200);
+    });
+
+    it("penalizes 100 points for a second waste recycle in Draw 1 mode", () => {
+      game.startNewGame();
+      game.setDrawCount(1);
+      const king = game.getCardById(CLUB_KING_ID)!;
+      forceWasteRecycle(game, king);
+      game.state.score = 200;
+
+      forceWasteRecycle(game, king);
+
+      expect(game.state.score).toBe(100);
+    });
+
+    it("does not penalize the first three waste recycles in Draw 3 mode", () => {
+      game.startNewGame();
+      game.setDrawCount(3);
+      const king = game.getCardById(CLUB_KING_ID)!;
+      game.state.score = 200;
+
+      forceWasteRecycle(game, king);
+      forceWasteRecycle(game, king);
+      forceWasteRecycle(game, king);
+
+      expect(game.state.score).toBe(200);
+    });
+
+    it("penalizes 20 points for a fourth waste recycle in Draw 3 mode", () => {
+      game.startNewGame();
+      game.setDrawCount(3);
+      const king = game.getCardById(CLUB_KING_ID)!;
+      forceWasteRecycle(game, king);
+      forceWasteRecycle(game, king);
+      forceWasteRecycle(game, king);
+      game.state.score = 200;
+
+      forceWasteRecycle(game, king);
+
+      expect(game.state.score).toBe(180);
+    });
+  });
+
+  describe("settings", () => {
+    it("starts a new game with the default draw count and card back", () => {
+      game.startNewGame();
+
       expect(game.settings.drawCount).toBe(3);
       expect(game.settings.cardBackStyle).toBe("card-back-blue");
     });
 
-    it("allows updating options via setters and pushes through BehaviorSubjects", () => {
-      const drawCountValues: (1 | 3)[] = [];
-      const cardBackValues: string[] = [];
-      const cardBackListener = vi.fn();
-
-      game.settings.drawCount$.subscribe((v) => drawCountValues.push(v));
-      game.settings.cardBackStyle$.subscribe((v) => cardBackValues.push(v));
-      game.on("card-back-changed", cardBackListener);
+    it("publishes the new draw count when it changes", () => {
+      const drawCounts: (1 | 3)[] = [];
+      game.settings.drawCount$.subscribe((v) => drawCounts.push(v));
 
       game.setDrawCount(1);
+
       expect(game.settings.drawCount).toBe(1);
-      expect(drawCountValues).toContain(1);
+      expect(drawCounts).toContain(1);
+    });
+
+    it("publishes and emits the new card back style when it changes", () => {
+      const cardBacks: string[] = [];
+      const cardBackEvents: { cardBackStyle: string }[] = [];
+      game.settings.cardBackStyle$.subscribe((v) => cardBacks.push(v));
+      game.on("card-back-changed", (payload) => cardBackEvents.push(payload));
 
       game.setCardBackStyle("card-back-red");
+
       expect(game.settings.cardBackStyle).toBe("card-back-red");
-      expect(cardBackValues).toContain("card-back-red");
-      expect(cardBackListener).toHaveBeenCalledWith({
-        cardBackStyle: "card-back-red",
-      });
-    });
-
-    it("increments moves and scores +5 when moving waste to tableau", () => {
-      game.startNewGame();
-      const card = game.getCardById("card-spades-jack")!;
-      const tableauCard = game.tableaus[0].getCards()[0];
-
-      game.getPileContainingCard(card.id)?.removeCard(card);
-      game.waste.clear();
-      card.faceUp = true;
-      card.type = Type.QUEEN;
-      card.suite = Suit.HEART;
-      game.waste.addCard(card);
-
-      tableauCard.faceUp = true;
-      tableauCard.type = Type.KING;
-      tableauCard.suite = Suit.SPADE;
-
-      const moved = game.moveCardToPile(card.id, game.tableaus[0].id);
-      expect(moved).toBe(true);
-      expect(game.state.score).toBe(5);
-      expect(game.state.moves).toBe(1);
-    });
-
-    it("scores +10 when moving waste to foundation", () => {
-      game.startNewGame();
-      const card = game.getCardById("card-spades-ace")!;
-      game.getPileContainingCard(card.id)?.removeCard(card);
-      game.waste.clear();
-      card.faceUp = true;
-      card.type = Type.ACE;
-      game.waste.addCard(card);
-
-      const moved = game.moveCardToPile(card.id, game.foundations[0].id);
-      expect(moved).toBe(true);
-      expect(game.state.score).toBe(10);
-      expect(game.state.moves).toBe(1);
-    });
-
-    it("scores +10 when moving tableau to foundation", () => {
-      game.startNewGame();
-      const card = game.getCardById("card-hearts-ace")!;
-      game.getPileContainingCard(card.id)?.removeCard(card);
-      game.tableaus[0].clear();
-      card.faceUp = true;
-      card.type = Type.ACE;
-      game.tableaus[0].addCard(card);
-
-      const moved = game.moveCardToPile(card.id, game.foundations[1].id);
-      expect(moved).toBe(true);
-      expect(game.state.score).toBe(10);
-    });
-
-    it("scores -15 when moving foundation to tableau", () => {
-      game.startNewGame();
-
-      const ace = game.getCardById("card-clubs-ace")!;
-      const two = game.getCardById("card-diamonds-2")!;
-
-      game.getPileContainingCard(ace.id)?.removeCard(ace);
-      game.getPileContainingCard(two.id)?.removeCard(two);
-
-      game.foundations[0].clear();
-      ace.faceUp = true;
-      ace.type = Type.ACE;
-      ace.suite = Suit.CLUB;
-      game.foundations[0].addCard(ace);
-
-      game.tableaus[0].clear();
-      two.faceUp = true;
-      two.type = Type.TWO;
-      two.suite = Suit.DIAMOND;
-      game.tableaus[0].addCard(two);
-
-      game.state.score = 20;
-
-      const moved = game.moveCardToPile(ace.id, game.tableaus[0].id);
-      expect(moved).toBe(true);
-      expect(game.state.score).toBe(5);
-    });
-
-    it("scores +5 when flipping a tableau card face up via moveCardToPile auto-flip", () => {
-      game.startNewGame();
-
-      game.tableaus[0].clear();
-      const cardDown = game.getCardById("card-spades-10")!;
-      game.getPileContainingCard(cardDown.id)?.removeCard(cardDown);
-      cardDown.faceUp = false;
-      game.tableaus[0].addCard(cardDown);
-
-      const cardUp = game.getCardById("card-hearts-ace")!;
-      game.getPileContainingCard(cardUp.id)?.removeCard(cardUp);
-      cardUp.faceUp = true;
-      cardUp.type = Type.ACE;
-      game.tableaus[0].addCard(cardUp);
-
-      game.foundations[0].clear();
-      const moved = game.moveCardToPile(cardUp.id, game.foundations[0].id);
-      expect(moved).toBe(true);
-      expect(cardDown.faceUp).toBe(true);
-      expect(game.state.score).toBe(15);
-    });
-
-    it("recycles waste and applies proper score penalty for Draw 1 vs Draw 3", () => {
-      game.startNewGame();
-      game.setDrawCount(1);
-
-      game.stock.clear();
-      const card = game.getCardById("card-clubs-king")!;
-      game.waste.clear();
-      game.waste.addCard(card);
-
-      game.state.score = 200;
-
-      game.drawCardsFromStock();
-      expect(game.state.score).toBe(200);
-
-      game.stock.clear();
-      game.waste.addCard(card);
-
-      game.drawCardsFromStock();
-      expect(game.state.score).toBe(100);
-
-      game.setDrawCount(3);
-      game.state.score = 200;
-      game.startNewGame();
-      game.setDrawCount(3);
-      game.state.score = 200;
-
-      for (let i = 0; i < 3; i++) {
-        game.stock.clear();
-        game.waste.addCard(card);
-        game.drawCardsFromStock();
-      }
-      expect(game.state.score).toBe(200);
-
-      game.stock.clear();
-      game.waste.addCard(card);
-      game.drawCardsFromStock();
-      expect(game.state.score).toBe(180);
+      expect(cardBacks).toContain("card-back-red");
+      expect(cardBackEvents).toEqual([{ cardBackStyle: "card-back-red" }]);
     });
   });
 });

--- a/test/game/render/asset/card_assets.spec.ts
+++ b/test/game/render/asset/card_assets.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { playingCardIdToFileName } from "@/game/render/asset/card_assets";
+import { Suit, Type } from "@/game/model/card/playing_card";
+
+describe("playingCardIdToFileName", () => {
+  it("maps a suit and type to its atlas frame name", () => {
+    const fileName = playingCardIdToFileName({
+      suit: Suit.HEART,
+      type: Type.QUEEN,
+    });
+
+    expect(fileName).toBe("card-hearts-queen");
+  });
+
+  it("throws for an unknown suit", () => {
+    expect(() =>
+      playingCardIdToFileName({ suit: 999 as Suit, type: Type.ACE }),
+    ).toThrow("Unknown Suit: 999");
+  });
+
+  it("throws for an unknown type", () => {
+    expect(() =>
+      playingCardIdToFileName({ suit: Suit.SPADE, type: 999 as Type }),
+    ).toThrow("Unknown Type: 999");
+  });
+});

--- a/test/game/render/scene/board/board_scene.spec.ts
+++ b/test/game/render/scene/board/board_scene.spec.ts
@@ -3,178 +3,17 @@ import * as Phaser from "phaser";
 import { BoardScene } from "@/game/render/scene/board/board_scene";
 import { SolitaireGame } from "@/game/model/game/solitaire_game";
 import { resetGameModel } from "@/game/model/game/game_model_factory";
-import {
-  Suit,
-  Type,
-  ALL_PLAYING_CARD_IDS,
-} from "@/game/model/card/playing_card";
+import { MockScaleManager, MockSprite } from "@test/support/phaser_mocks";
 
-// Mock phaser entirely
-vi.mock("phaser", () => {
-  const createMockSprite = (x = 0, y = 0, texture = "", frame = "") => {
-    const listeners: { [event: string]: Function[] } = {};
-    const dataMap = new Map<string, any>();
-    const sprite = {
-      x,
-      y,
-      scale: 1,
-      depth: 0,
-      alpha: 1,
-      frame,
-      originX: 0,
-      originY: 0,
-      setOrigin: vi.fn().mockImplementation(function (
-        this: any,
-        x: number,
-        y: number,
-      ) {
-        this.originX = x;
-        this.originY = y;
-        return this;
-      }),
-      setInteractive: vi.fn().mockImplementation(function (this: any) {
-        this.input = { cursor: "pointer" };
-        return this;
-      }),
-      on: vi.fn().mockImplementation((event: string, cb: Function) => {
-        if (!listeners[event]) {
-          listeners[event] = [];
-        }
-        listeners[event].push(cb);
-        return sprite;
-      }),
-      emit: (event: string, ...args: any[]) => {
-        if (listeners[event]) {
-          listeners[event].forEach((cb) => cb(...args));
-        }
-      },
-      setFrame: vi.fn().mockImplementation(function (this: any, frame: string) {
-        this.frame = frame;
-        return this;
-      }),
-      setPosition: vi.fn().mockImplementation(function (
-        this: any,
-        x: number,
-        y: number,
-      ) {
-        this.x = x;
-        this.y = y;
-        return this;
-      }),
-      setScale: vi.fn().mockImplementation(function (this: any, scale: number) {
-        this.scale = scale;
-        return this;
-      }),
-      setDepth: vi.fn().mockImplementation(function (this: any, depth: number) {
-        this.depth = depth;
-        return this;
-      }),
-      setAlpha: vi.fn().mockImplementation(function (this: any, alpha: number) {
-        this.alpha = alpha;
-        return this;
-      }),
-      setData: vi.fn().mockImplementation((key: string, val: any) => {
-        dataMap.set(key, val);
-        return sprite;
-      }),
-      getData: vi.fn().mockImplementation((key: string) => {
-        return dataMap.get(key);
-      }),
-      displayWidth: 220,
-      displayHeight: 307,
-      input: undefined,
-      active: true,
-      enableFilters: vi.fn().mockReturnThis(),
-      filters: {
-        external: {
-          addShadow: vi.fn().mockImplementation(() => ({
-            x: 2,
-            y: 3,
-            decay: 0.2,
-            intensity: 0.4,
-            setPaddingOverride: vi.fn(),
-          })),
-        },
-      },
-    };
-    return sprite;
-  };
-
-  return {
-    Scene: class MockScene {
-      add = {
-        graphics: vi.fn(() => ({
-          clear: vi.fn().mockReturnThis(),
-          lineStyle: vi.fn().mockReturnThis(),
-          strokeRect: vi.fn().mockReturnThis(),
-          strokeRoundedRect: vi.fn().mockReturnThis(),
-          setDepth: vi.fn().mockReturnThis(),
-        })),
-        sprite: vi.fn((x, y, texture, frame) =>
-          createMockSprite(x, y, texture, frame),
-        ),
-      };
-      scale = {
-        on: vi.fn(),
-      };
-      input: any;
-      constructor() {
-        const listeners: { [event: string]: { cb: Function; context?: any } } =
-          {};
-        this.input = {
-          on: vi
-            .fn()
-            .mockImplementation(
-              (event: string, cb: Function, context?: any) => {
-                listeners[event] = { cb, context };
-                return this.input;
-              },
-            ),
-          setDraggable: vi.fn(),
-          _trigger: (event: string, ...args: any[]) => {
-            const listener = listeners[event];
-            if (listener) {
-              listener.cb.apply(listener.context, args);
-            }
-          },
-        };
-      }
-    },
-    Geom: {
-      Rectangle: Object.assign(
-        class MockRectangle {
-          constructor(
-            public x = 0,
-            public y = 0,
-            public width = 0,
-            public height = 0,
-          ) {}
-        },
-        {
-          Intersection: (rect1: any, rect2: any, out: any) => {
-            const x5 = Math.max(rect1.x, rect2.x);
-            const y5 = Math.max(rect1.y, rect2.y);
-            const x6 = Math.min(rect1.x + rect1.width, rect2.x + rect2.width);
-            const y6 = Math.min(rect1.y + rect1.height, rect2.y + rect2.height);
-
-            if (x5 >= x6 || y5 >= y6) {
-              out.x = 0;
-              out.y = 0;
-              out.width = 0;
-              out.height = 0;
-            } else {
-              out.x = x5;
-              out.y = y5;
-              out.width = x6 - x5;
-              out.height = y6 - y5;
-            }
-            return out;
-          },
-        },
-      ),
-    },
-  };
+vi.mock("phaser", async () => {
+  const mocks = await import("@test/support/phaser_mocks");
+  return mocks.boardScenePhaserMock();
 });
+
+/** Views a Phaser sprite handle as the underlying recording mock sprite. */
+function asMock(sprite: unknown): MockSprite {
+  return sprite as unknown as MockSprite;
+}
 
 describe("BoardScene", () => {
   let boardScene: BoardScene;
@@ -185,321 +24,249 @@ describe("BoardScene", () => {
     boardScene.create();
   });
 
-  it("assigns background placeholder sprite to stock pile", () => {
-    expect(boardScene.stockPile.sprite).toBeDefined();
-    expect(boardScene.stockPile.sprite).not.toBeNull();
-    expect(boardScene.stockPile.sprite.frame).toBe(
-      "card-placeholder-full-border-reset",
-    );
-    expect(boardScene.stockPile.sprite.alpha).toBe(
-      BoardScene.PILE_BACKGROUND_ALPHA,
-    );
-  });
+  describe("pile backgrounds", () => {
+    it("gives the stock pile a placeholder background at the shared alpha", () => {
+      const sprite = asMock(boardScene.stockPile.sprite);
 
-  it("assigns background placeholder sprites to tableau piles", () => {
-    for (const tableauPile of boardScene.tableauPiles) {
-      expect(tableauPile.sprite).toBeDefined();
-      expect(tableauPile.sprite).not.toBeNull();
-      expect(tableauPile.sprite.frame).toBe("card-placeholder");
-      expect(tableauPile.sprite.alpha).toBe(BoardScene.PILE_BACKGROUND_ALPHA);
-    }
-  });
+      expect(sprite.frame).toBe("card-placeholder-full-border-reset");
+      expect(sprite.alpha).toBe(BoardScene.PILE_BACKGROUND_ALPHA);
+    });
 
-  it("assigns background placeholder sprites to foundation piles", () => {
-    for (const foundationPile of boardScene.foundationPiles) {
-      expect(foundationPile.sprite).toBeDefined();
-      expect(foundationPile.sprite).not.toBeNull();
-      expect(foundationPile.sprite.frame).toBe(
-        "card-placeholder-full-border-circle",
+    it("gives every tableau pile a placeholder background at the shared alpha", () => {
+      const frames = boardScene.tableauPiles.map((p) => asMock(p.sprite).frame);
+      const alphas = boardScene.tableauPiles.map((p) => asMock(p.sprite).alpha);
+
+      expect(frames).toEqual(Array(7).fill("card-placeholder"));
+      expect(alphas).toEqual(Array(7).fill(BoardScene.PILE_BACKGROUND_ALPHA));
+    });
+
+    it("gives every foundation pile a placeholder background at the shared alpha", () => {
+      const frames = boardScene.foundationPiles.map(
+        (p) => asMock(p.sprite).frame,
       );
-      expect(foundationPile.sprite.alpha).toBe(
-        BoardScene.PILE_BACKGROUND_ALPHA,
+      const alphas = boardScene.foundationPiles.map(
+        (p) => asMock(p.sprite).alpha,
       );
-    }
+
+      expect(frames).toEqual(
+        Array(4).fill("card-placeholder-full-border-circle"),
+      );
+      expect(alphas).toEqual(Array(4).fill(BoardScene.PILE_BACKGROUND_ALPHA));
+    });
   });
 
-  it("updates hand cursor for cards based on interactability", () => {
-    const tableau1 = boardScene.tableauPiles[1];
-    const cardVisualBottom = tableau1.playingCardVisuals[0];
-    const cardVisualTop = tableau1.playingCardVisuals[1];
+  describe("cursors and draggability", () => {
+    it("uses a pointer cursor only for interactable cards", () => {
+      const tableau = boardScene.tableauPiles[1];
 
-    expect(cardVisualBottom.sprite.input.cursor).toBe("default");
-    expect(cardVisualTop.sprite.input.cursor).toBe("pointer");
-  });
-
-  it("sets hand cursor to default after flipping top card face down", () => {
-    const tableau0 = boardScene.tableauPiles[0];
-    const cardVisual0 = tableau0.playingCardVisuals[0];
-    const card0 = cardVisual0.playingCard;
-    card0.faceUp = false;
-
-    boardScene.gameModel.emit("card-flipped", {
-      cardId: card0.id,
-      faceUp: false,
+      expect(asMock(tableau.playingCardVisuals[0].sprite).input?.cursor).toBe(
+        "default",
+      );
+      expect(asMock(tableau.playingCardVisuals[1].sprite).input?.cursor).toBe(
+        "pointer",
+      );
     });
 
-    expect(cardVisual0.sprite.input.cursor).toBe("default");
-  });
+    it("resets a card's cursor to default when it is flipped face down", () => {
+      const cardVisual = boardScene.tableauPiles[0].playingCardVisuals[0];
+      cardVisual.playingCard.faceUp = false;
 
-  it("sets draggability based on whether the card is draggable, not just interactable", () => {
-    vi.mocked(boardScene.input.setDraggable).mockClear();
-
-    boardScene.gameModel.emit("card-flipped", {
-      cardId: "card-clubs-ace",
-      faceUp: true,
-    });
-
-    const stockPile = boardScene.stockPile;
-    const topStockCardVisual =
-      stockPile.playingCardVisuals[stockPile.playingCardVisuals.length - 1];
-    const tableau0 = boardScene.tableauPiles[0];
-    const tableauCardVisual =
-      tableau0.playingCardVisuals[tableau0.playingCardVisuals.length - 1];
-
-    expect(boardScene.input.setDraggable).toHaveBeenCalledWith(
-      topStockCardVisual.sprite,
-      false,
-    );
-    expect(boardScene.input.setDraggable).toHaveBeenCalledWith(
-      tableauCardVisual.sprite,
-      true,
-    );
-  });
-
-  it("getPileVisualById returns the pile or null if not found", () => {
-    expect(boardScene.getPileVisualById("stock")).toBe(boardScene.stockPile);
-    expect(boardScene.getPileVisualById("non-existent-pile")).toBeNull();
-  });
-
-  it("triggers layout updates when the scale resize event fires", () => {
-    boardScene.scale.width = 903.5;
-    boardScene.scale.height = 475;
-    const scaleOnCalls = vi.mocked(boardScene.scale.on).mock.calls;
-    const resizeCall = scaleOnCalls.find(
-      (call: unknown[]) => call[0] === "resize",
-    );
-    expect(resizeCall).toBeDefined();
-
-    const resizeCallback = resizeCall[1];
-    resizeCallback();
-
-    expect(boardScene.stockPile.position).toEqual({ x: 20, y: 20 });
-  });
-
-  it("initially populates stock pile visuals with playing cards", () => {
-    expect(boardScene.stockPile.playingCardVisuals.length).toBeGreaterThan(0);
-  });
-
-  it("syncs visual piles on card-moved event", () => {
-    const game = boardScene.gameModel;
-    game.stock.clear();
-
-    game.emit("card-moved");
-
-    expect(boardScene.stockPile.playingCardVisuals.length).toBe(0);
-  });
-
-  it("syncs visual piles on stock-recycled event", () => {
-    const game = boardScene.gameModel;
-    game.stock.clear();
-
-    game.emit("stock-recycled");
-
-    expect(boardScene.stockPile.playingCardVisuals.length).toBe(0);
-  });
-
-  it("logs a message on game-won event", () => {
-    const game = boardScene.gameModel;
-    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    game.emit("game-won");
-
-    expect(consoleLogSpy).toHaveBeenCalledWith("Congratulations! You won!");
-    consoleLogSpy.mockRestore();
-  });
-
-  it("updates card sprite frame to card ID on card-flipped event (faceUp true)", () => {
-    const game = boardScene.gameModel;
-    const tableau0 = boardScene.tableauPiles[0];
-    const visual0 = tableau0.playingCardVisuals[0];
-
-    game.emit("card-flipped", { cardId: visual0.playingCard.id, faceUp: true });
-
-    expect(visual0.sprite.frame).toBe(visual0.playingCard.id);
-  });
-
-  it("updates card sprite frame to card-back-blue on card-flipped event (faceUp false)", () => {
-    const game = boardScene.gameModel;
-    const tableau0 = boardScene.tableauPiles[0];
-    const visual0 = tableau0.playingCardVisuals[0];
-
-    game.emit("card-flipped", {
-      cardId: visual0.playingCard.id,
-      faceUp: false,
-    });
-
-    expect(visual0.sprite.frame).toBe("card-back-blue");
-  });
-
-  it("does not crash on card-flipped event if card visual lacks a sprite", () => {
-    const game = boardScene.gameModel;
-    const tableau0 = boardScene.tableauPiles[0];
-    const visual0 = tableau0.playingCardVisuals[0];
-    const oldSprite = visual0.sprite;
-    visual0.sprite = null as unknown as Phaser.GameObjects.Sprite;
-
-    expect(() => {
-      game.emit("card-flipped", {
-        cardId: visual0.playingCard.id,
-        faceUp: true,
+      boardScene.gameModel.emit("card-flipped", {
+        cardId: cardVisual.playingCard.id,
+        faceUp: false,
       });
-    }).not.toThrow();
-    visual0.sprite = oldSprite;
-  });
 
-  it("throws error in createCardVisuals if a card model is not found", () => {
-    resetGameModel();
-    const customBoardScene = new BoardScene();
-    const getCardSpy = vi
-      .spyOn(SolitaireGame.prototype, "getCardById")
-      .mockReturnValue(undefined);
+      expect(asMock(cardVisual.sprite).input?.cursor).toBe("default");
+    });
 
-    expect(() => customBoardScene.create()).toThrow(
-      "Card model not found for: ",
-    );
-    getCardSpy.mockRestore();
-  });
+    it("makes only draggable cards draggable, not merely interactable ones", () => {
+      vi.mocked(boardScene.input.setDraggable).mockClear();
 
-  it("syncVisualPilesWithModel syncs foundation cards correctly", () => {
-    const card = boardScene.tableauPiles[0].playingCardVisuals[0].playingCard;
-    const sourcePile = boardScene.gameModel.getPileContainingCard(card.id);
-    sourcePile?.removeCard(card);
-    boardScene.gameModel.foundations[0].addCard(card);
-
-    boardScene.gameModel.emit("card-moved");
-
-    expect(boardScene.foundationPiles[0].playingCardVisuals.length).toBe(1);
-    expect(
-      boardScene.foundationPiles[0].playingCardVisuals[0].playingCard,
-    ).toBe(card);
-  });
-
-  it("syncVisualPilesWithModel ignores cards not in cardVisualsMap", () => {
-    resetGameModel();
-    const customBoardScene = new BoardScene();
-    customBoardScene.create();
-
-    const stockCard = customBoardScene.gameModel.stock.getCards()[0];
-    customBoardScene.cardVisualsMap.delete(stockCard.id);
-
-    const wasteCard = customBoardScene.gameModel.stock.getCards()[1];
-    customBoardScene.gameModel.stock.removeCard(wasteCard);
-    customBoardScene.gameModel.waste.addCard(wasteCard);
-    customBoardScene.cardVisualsMap.delete(wasteCard.id);
-
-    const fCard = customBoardScene.gameModel.stock.getCards()[2];
-    customBoardScene.gameModel.stock.removeCard(fCard);
-    customBoardScene.gameModel.foundations[0].addCard(fCard);
-    customBoardScene.cardVisualsMap.delete(fCard.id);
-
-    const tCard =
-      customBoardScene.tableauPiles[0].playingCardVisuals[0].playingCard;
-    customBoardScene.cardVisualsMap.delete(tCard.id);
-
-    expect(() => {
-      customBoardScene.gameModel.emit("card-moved");
-    }).not.toThrow();
-  });
-
-  it("updateCardCursors handles stockPile.sprite or its input being null", () => {
-    const originalSprite = boardScene.stockPile.sprite;
-    boardScene.stockPile.sprite = null as unknown as Phaser.GameObjects.Sprite;
-
-    expect(() => {
       boardScene.gameModel.emit("card-flipped", {
         cardId: "card-clubs-ace",
         faceUp: true,
       });
-    }).not.toThrow();
 
-    boardScene.stockPile.sprite = {
-      input: null,
-    } as unknown as Phaser.GameObjects.Sprite;
-    expect(() => {
+      const stockPile = boardScene.stockPile;
+      const topStockCard =
+        stockPile.playingCardVisuals[stockPile.playingCardVisuals.length - 1];
+      const tableau = boardScene.tableauPiles[0];
+      const topTableauCard =
+        tableau.playingCardVisuals[tableau.playingCardVisuals.length - 1];
+
+      expect(boardScene.input.setDraggable).toHaveBeenCalledWith(
+        topStockCard.sprite,
+        false,
+      );
+      expect(boardScene.input.setDraggable).toHaveBeenCalledWith(
+        topTableauCard.sprite,
+        true,
+      );
+    });
+  });
+
+  describe("getPileVisualById", () => {
+    it("returns the pile visual for a known id", () => {
+      expect(boardScene.getPileVisualById("stock")).toBe(boardScene.stockPile);
+    });
+
+    it("returns null for an unknown id", () => {
+      expect(boardScene.getPileVisualById("non-existent-pile")).toBeNull();
+    });
+  });
+
+  describe("responsiveness", () => {
+    it("re-lays out the board when the viewport is resized", () => {
+      const scale = boardScene.scale as unknown as MockScaleManager;
+      scale.width = 903.5;
+      scale.height = 475;
+
+      scale.emit("resize");
+
+      expect(boardScene.stockPile.position).toEqual({ x: 20, y: 20 });
+    });
+  });
+
+  describe("model synchronization", () => {
+    it("populates the stock pile visuals on creation", () => {
+      expect(boardScene.stockPile.playingCardVisuals.length).toBeGreaterThan(0);
+    });
+
+    it("re-syncs visual piles when a card is moved", () => {
+      boardScene.gameModel.stock.clear();
+
+      boardScene.gameModel.emit("card-moved");
+
+      expect(boardScene.stockPile.playingCardVisuals.length).toBe(0);
+    });
+
+    it("re-syncs visual piles when the stock is recycled", () => {
+      boardScene.gameModel.stock.clear();
+
+      boardScene.gameModel.emit("stock-recycled");
+
+      expect(boardScene.stockPile.playingCardVisuals.length).toBe(0);
+    });
+
+    it("moves a card into the waste visual pile when the model does", () => {
+      const card = boardScene.tableauPiles[0].playingCardVisuals[0].playingCard;
+      boardScene.gameModel.getPileContainingCard(card.id)?.removeCard(card);
+      boardScene.gameModel.waste.addCard(card);
+
+      boardScene.gameModel.emit("card-moved");
+
+      expect(
+        boardScene.wastePile.playingCardVisuals.map((v) => v.playingCard),
+      ).toEqual([card]);
+    });
+
+    it("moves a card into the foundation visual pile when the model does", () => {
+      const card = boardScene.tableauPiles[0].playingCardVisuals[0].playingCard;
+      boardScene.gameModel.getPileContainingCard(card.id)?.removeCard(card);
+      boardScene.gameModel.foundations[0].addCard(card);
+
+      boardScene.gameModel.emit("card-moved");
+
+      expect(
+        boardScene.foundationPiles[0].playingCardVisuals.map(
+          (v) => v.playingCard,
+        ),
+      ).toEqual([card]);
+    });
+
+    it("ignores model cards that have no registered visual", () => {
+      const stockCard = boardScene.gameModel.stock.getCards()[0];
+      boardScene.cardVisualsMap.delete(stockCard.id);
+      const movedCard = boardScene.gameModel.stock.getCards()[1];
+      boardScene.gameModel.stock.removeCard(movedCard);
+      boardScene.gameModel.waste.addCard(movedCard);
+      boardScene.cardVisualsMap.delete(movedCard.id);
+
+      expect(() => boardScene.gameModel.emit("card-moved")).not.toThrow();
+    });
+  });
+
+  describe("card flipping", () => {
+    it("shows the card face when it is flipped face up", () => {
+      const visual = boardScene.tableauPiles[0].playingCardVisuals[0];
+
       boardScene.gameModel.emit("card-flipped", {
-        cardId: "card-clubs-ace",
+        cardId: visual.playingCard.id,
         faceUp: true,
       });
-    }).not.toThrow();
 
-    boardScene.stockPile.sprite = originalSprite;
+      expect(asMock(visual.sprite).frame).toBe(visual.playingCard.id);
+    });
+
+    it("shows the card back when it is flipped face down", () => {
+      const visual = boardScene.tableauPiles[0].playingCardVisuals[0];
+
+      boardScene.gameModel.emit("card-flipped", {
+        cardId: visual.playingCard.id,
+        faceUp: false,
+      });
+
+      expect(asMock(visual.sprite).frame).toBe("card-back-blue");
+    });
+
+    it("does not throw when the flipped card visual has no sprite", () => {
+      const visual = boardScene.tableauPiles[0].playingCardVisuals[0];
+      visual.sprite = null as unknown as Phaser.GameObjects.Sprite;
+
+      expect(() =>
+        boardScene.gameModel.emit("card-flipped", {
+          cardId: visual.playingCard.id,
+          faceUp: true,
+        }),
+      ).not.toThrow();
+    });
+
+    it("does not throw when the stock pile sprite or its input is missing", () => {
+      boardScene.stockPile.sprite =
+        null as unknown as Phaser.GameObjects.Sprite;
+      expect(() =>
+        boardScene.gameModel.emit("card-flipped", {
+          cardId: "card-clubs-ace",
+          faceUp: true,
+        }),
+      ).not.toThrow();
+
+      boardScene.stockPile.sprite = {
+        input: null,
+      } as unknown as Phaser.GameObjects.Sprite;
+      expect(() =>
+        boardScene.gameModel.emit("card-flipped", {
+          cardId: "card-clubs-ace",
+          faceUp: true,
+        }),
+      ).not.toThrow();
+    });
   });
 
-  it("throws error during creation if a card has an invalid suit", () => {
-    const invalidCard = { suit: 999 as unknown as Suit, type: Type.ACE };
-    ALL_PLAYING_CARD_IDS.push(invalidCard);
+  describe("creation errors and helpers", () => {
+    it("throws when a card model is missing while creating visuals", () => {
+      resetGameModel();
+      const freshScene = new BoardScene();
+      const getCardById = vi
+        .spyOn(SolitaireGame.prototype, "getCardById")
+        .mockReturnValue(undefined);
 
-    expect(() => {
-      boardScene.create();
-    }).toThrow("Unknown Suit: 999");
+      expect(() => freshScene.create()).toThrow("Card model not found for: ");
 
-    ALL_PLAYING_CARD_IDS.pop();
-  });
+      getCardById.mockRestore();
+    });
 
-  it("throws error during creation if a card has an invalid type", () => {
-    const invalidTypeCard = { suit: Suit.SPADE, type: 999 as unknown as Type };
-    ALL_PLAYING_CARD_IDS.push(invalidTypeCard);
+    it("logs a congratulations message when the game is won", () => {
+      const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    expect(() => {
-      boardScene.create();
-    }).toThrow("Unknown Type: 999");
+      boardScene.gameModel.emit("game-won");
 
-    ALL_PLAYING_CARD_IDS.pop();
-  });
+      expect(consoleLog).toHaveBeenCalledWith("Congratulations! You won!");
+      consoleLog.mockRestore();
+    });
 
-  it("provides backward compatibility getter and setter for hoveredCardVisual", () => {
-    const originalHovered = boardScene.hoveredCardVisual;
-    boardScene.hoveredCardVisual = originalHovered;
-    expect(boardScene.hoveredCardVisual).toBe(originalHovered);
-  });
-
-  it("provides backward compatibility getter and setter for isStockBackgroundHovered", () => {
-    const originalStockHovered = boardScene.isStockBackgroundHovered;
-    boardScene.isStockBackgroundHovered = originalStockHovered;
-    expect(boardScene.isStockBackgroundHovered).toBe(originalStockHovered);
-  });
-
-  it("provides backward compatibility getter and setter for draggedStack", () => {
-    const originalDragged = boardScene.draggedStack;
-    boardScene.draggedStack = originalDragged;
-    expect(boardScene.draggedStack).toBe(originalDragged);
-  });
-
-  it("provides backward compatibility getter and setter for draggedStackOffsets", () => {
-    const originalOffsets = boardScene.draggedStackOffsets;
-    boardScene.draggedStackOffsets = originalOffsets;
-    expect(boardScene.draggedStackOffsets).toBe(originalOffsets);
-  });
-
-  it("provides backward compatibility getter and setter for highlightGraphics", () => {
-    const originalGraphics = boardScene.highlightGraphics;
-    boardScene.highlightGraphics = originalGraphics;
-    expect(boardScene.highlightGraphics).toBe(originalGraphics);
-  });
-
-  it("provides getLayoutManager returning layout manager instance", () => {
-    expect(boardScene.getLayoutManager()).toBeDefined();
-  });
-
-  it("syncVisualPilesWithModel syncs waste cards correctly", () => {
-    const card = boardScene.tableauPiles[0].playingCardVisuals[0].playingCard;
-    const sourcePile = boardScene.gameModel.getPileContainingCard(card.id);
-    sourcePile?.removeCard(card);
-    boardScene.gameModel.waste.addCard(card);
-
-    boardScene.gameModel.emit("card-moved");
-
-    expect(boardScene.wastePile.playingCardVisuals.length).toBe(1);
-    expect(boardScene.wastePile.playingCardVisuals[0].playingCard).toBe(card);
+    it("exposes the layout manager", () => {
+      expect(boardScene.getLayoutManager()).toBeDefined();
+    });
   });
 });

--- a/test/game/render/scene/board/board_visual_factory.spec.ts
+++ b/test/game/render/scene/board/board_visual_factory.spec.ts
@@ -1,128 +1,22 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import * as Phaser from "phaser";
 import { BoardVisualFactory } from "@/game/render/scene/board/board_visual_factory";
-
-interface MockSprite extends Phaser.GameObjects.Sprite {
-  originX: number;
-  originY: number;
-  interactiveConfig: { useHandCursor: boolean } | null;
-  filtersEnabled: boolean;
-  shadowsAdded: {
-    x: number;
-    y: number;
-    decay: number;
-    intensity: number;
-    color: number;
-    blur: number;
-    opacity: number;
-  }[];
-}
-
-// Mock phaser entirely
-vi.mock("phaser", () => {
-  const createMockSprite = (x = 0, y = 0, texture = "", frame = "") => {
-    const sprite = {
-      x,
-      y,
-      alpha: 1,
-      originX: 0,
-      originY: 0,
-      interactiveConfig: null as unknown as { useHandCursor: boolean } | null,
-      filtersEnabled: false,
-      shadowsAdded: [] as {
-        x: number;
-        y: number;
-        decay: number;
-        intensity: number;
-        color: number;
-        blur: number;
-        opacity: number;
-      }[],
-      setOrigin: vi.fn().mockImplementation(function (
-        this: { originX: number; originY: number },
-        x: number,
-        y: number,
-      ) {
-        this.originX = x;
-        this.originY = y;
-        return this;
-      }),
-      setAlpha: vi.fn().mockImplementation(function (
-        this: { alpha: number },
-        alpha: number,
-      ) {
-        this.alpha = alpha;
-        return this;
-      }),
-      setInteractive: vi.fn().mockImplementation(function (
-        this: { interactiveConfig: unknown },
-        config: unknown,
-      ) {
-        this.interactiveConfig = config as { useHandCursor: boolean } | null;
-        return this;
-      }),
-      enableFilters: vi.fn().mockImplementation(function (this: {
-        filtersEnabled: boolean;
-      }) {
-        this.filtersEnabled = true;
-        return this;
-      }),
-      filters: {
-        external: {
-          addShadow: vi.fn().mockImplementation(function (
-            x: number,
-            y: number,
-            decay: number,
-            intensity: number,
-            color: number,
-            blur: number,
-            opacity: number,
-          ) {
-            sprite.shadowsAdded.push({
-              x,
-              y,
-              decay,
-              intensity,
-              color,
-              blur,
-              opacity,
-            });
-            return sprite;
-          }),
-        },
-      },
-      texture,
-      frame,
-    };
-    return sprite as unknown as Phaser.GameObjects.Sprite;
-  };
-
-  return {
-    Scene: class MockScene {
-      add = {
-        sprite: vi.fn((x, y, texture, frame) =>
-          createMockSprite(x, y, texture, frame),
-        ),
-      };
-    },
-  };
-});
+import { createMockSprite, MockSprite } from "@test/support/phaser_mocks";
 
 describe("BoardVisualFactory", () => {
-  let mockScene: Phaser.Scene;
+  let addSprite: ReturnType<typeof vi.fn>;
   let factory: BoardVisualFactory;
 
   beforeEach(() => {
-    mockScene = new Phaser.Scene({ key: "test-scene" });
-    factory = new BoardVisualFactory(mockScene);
+    addSprite = vi.fn(() => createMockSprite());
+    const scene = { add: { sprite: addSprite } } as unknown as Phaser.Scene;
+    factory = new BoardVisualFactory(scene);
   });
 
-  it("createCardSprite creates a card sprite with standard origin, interactive inputs, and shadow filters", () => {
-    // Act
+  it("creates a card sprite from the card-back frame with a standard origin", () => {
     const sprite = factory.createCardSprite() as unknown as MockSprite;
 
-    // Assert
-    expect(mockScene.add.sprite).toHaveBeenCalledWith(
+    expect(addSprite).toHaveBeenCalledWith(
       0,
       0,
       "card_assets",
@@ -130,40 +24,44 @@ describe("BoardVisualFactory", () => {
     );
     expect(sprite.originX).toBe(0);
     expect(sprite.originY).toBe(0);
-    expect(sprite.interactiveConfig).toEqual({ useHandCursor: true });
-    expect(sprite.filtersEnabled).toBe(true);
-    expect(sprite.shadowsAdded).toHaveLength(2);
-    expect(sprite.shadowsAdded[0]).toEqual({
-      x: 0.5,
-      y: 0.5,
-      decay: 0.05,
-      intensity: 0.8,
-      color: 0x000000,
-      blur: 6,
-      opacity: 0.05,
-    });
-    expect(sprite.shadowsAdded[1]).toEqual({
-      x: 0,
-      y: 0,
-      decay: 0.1,
-      intensity: 0.8,
-      color: 0x000000,
-      blur: 6,
-      opacity: 0.05,
-    });
   });
 
-  it("createStockBackground creates stock pile background with origin, alpha, and interactive input", () => {
-    // Arrange
-    const alpha = 0.5;
+  it("makes the card sprite interactive with a hand cursor", () => {
+    const sprite = factory.createCardSprite() as unknown as MockSprite;
 
-    // Act
-    const sprite = factory.createStockBackground(
-      alpha,
-    ) as unknown as MockSprite;
+    expect(sprite.interactiveConfig).toEqual({ useHandCursor: true });
+  });
 
-    // Assert
-    expect(mockScene.add.sprite).toHaveBeenCalledWith(
+  it("gives the card sprite two drop-shadow filters", () => {
+    const sprite = factory.createCardSprite() as unknown as MockSprite;
+
+    expect(sprite.filtersEnabled).toBe(true);
+    expect(sprite.shadowsAdded).toEqual([
+      {
+        x: 0.5,
+        y: 0.5,
+        decay: 0.05,
+        intensity: 0.8,
+        color: 0x000000,
+        blur: 6,
+        opacity: 0.05,
+      },
+      {
+        x: 0,
+        y: 0,
+        decay: 0.1,
+        intensity: 0.8,
+        color: 0x000000,
+        blur: 6,
+        opacity: 0.05,
+      },
+    ]);
+  });
+
+  it("creates an interactive stock background with the given alpha", () => {
+    const sprite = factory.createStockBackground(0.5) as unknown as MockSprite;
+
+    expect(addSprite).toHaveBeenCalledWith(
       0,
       0,
       "card_assets",
@@ -171,51 +69,37 @@ describe("BoardVisualFactory", () => {
     );
     expect(sprite.originX).toBe(0);
     expect(sprite.originY).toBe(0);
-    expect(sprite.alpha).toBe(alpha);
+    expect(sprite.alpha).toBe(0.5);
     expect(sprite.interactiveConfig).toEqual({ useHandCursor: true });
   });
 
-  it("createTableauBackground creates tableau pile background with origin and alpha", () => {
-    // Arrange
-    const alpha = 0.4;
-
-    // Act
+  it("creates a non-interactive tableau background with the given alpha", () => {
     const sprite = factory.createTableauBackground(
-      alpha,
+      0.4,
     ) as unknown as MockSprite;
 
-    // Assert
-    expect(mockScene.add.sprite).toHaveBeenCalledWith(
+    expect(addSprite).toHaveBeenCalledWith(
       0,
       0,
       "card_assets",
       "card-placeholder",
     );
-    expect(sprite.originX).toBe(0);
-    expect(sprite.originY).toBe(0);
-    expect(sprite.alpha).toBe(alpha);
+    expect(sprite.alpha).toBe(0.4);
     expect(sprite.interactiveConfig).toBeNull();
   });
 
-  it("createFoundationBackground creates foundation pile background with origin and alpha", () => {
-    // Arrange
-    const alpha = 0.6;
-
-    // Act
+  it("creates a non-interactive foundation background with the given alpha", () => {
     const sprite = factory.createFoundationBackground(
-      alpha,
+      0.6,
     ) as unknown as MockSprite;
 
-    // Assert
-    expect(mockScene.add.sprite).toHaveBeenCalledWith(
+    expect(addSprite).toHaveBeenCalledWith(
       0,
       0,
       "card_assets",
       "card-placeholder-full-border-circle",
     );
-    expect(sprite.originX).toBe(0);
-    expect(sprite.originY).toBe(0);
-    expect(sprite.alpha).toBe(alpha);
+    expect(sprite.alpha).toBe(0.6);
     expect(sprite.interactiveConfig).toBeNull();
   });
 });

--- a/test/game/render/scene/board/effects/board_highlight_renderer.spec.ts
+++ b/test/game/render/scene/board/effects/board_highlight_renderer.spec.ts
@@ -1,191 +1,151 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import * as Phaser from "phaser";
 import { BoardHighlightRenderer } from "@/game/render/scene/board/effects/board_highlight_renderer";
+import { BoardScene } from "@/game/render/scene/board/board_scene";
 import { SolitaireGame } from "@/game/model/game/solitaire_game";
 import { PlayingCardVisual } from "@/game/render/visual/card/playing_card_visual";
+import { PlayingCard } from "@/game/model/card/playing_card";
+import {
+  asSprite,
+  createMockGraphics,
+  createMockSprite,
+  MockGraphics,
+  MockSprite,
+} from "@test/support/phaser_mocks";
+
+const SCALE_FACTOR = 1.5;
 
 describe("BoardHighlightRenderer", () => {
-  let mockGraphics: any;
-  let mockBoardScene: any;
+  let graphics: MockGraphics;
   let gameModel: SolitaireGame;
+  let stockSprite: MockSprite;
   let renderer: BoardHighlightRenderer;
 
   beforeEach(() => {
-    mockGraphics = {
-      clear: vi.fn().mockReturnThis(),
-      lineStyle: vi.fn().mockReturnThis(),
-      strokeRoundedRect: vi.fn().mockReturnThis(),
-      setDepth: vi.fn().mockReturnThis(),
-    };
-
+    graphics = createMockGraphics();
     gameModel = new SolitaireGame();
-    // Start game so that stock isn't empty, tableaus are populated, etc.
     gameModel.startNewGame();
+    stockSprite = createMockSprite({
+      x: 20,
+      y: 20,
+      displayWidth: 100,
+      displayHeight: 150,
+    });
 
-    mockBoardScene = {
-      add: {
-        graphics: vi.fn().mockReturnValue(mockGraphics),
-      },
+    const boardScene = {
+      add: { graphics: () => graphics },
       gameModel,
-      stockPile: {
-        sprite: {
-          active: true,
-          displayWidth: 100,
-          displayHeight: 150,
-          x: 20,
-          y: 20,
-        },
-      },
-      getLayoutManager: () => ({
-        getScaleFactor: () => 1.5,
-      }),
-    };
+      stockPile: { sprite: asSprite(stockSprite) },
+      getLayoutManager: () => ({ getScaleFactor: () => SCALE_FACTOR }),
+    } as unknown as BoardScene;
 
-    renderer = new BoardHighlightRenderer(mockBoardScene);
+    renderer = new BoardHighlightRenderer(boardScene);
   });
 
-  it("does not crash when graphics is null", () => {
-    // Arrange
+  /** Builds a card visual backed by a mock sprite at the given position. */
+  function hoveredVisual(card: PlayingCard): PlayingCardVisual {
+    const visual = new PlayingCardVisual(card);
+    visual.sprite = asSprite(
+      createMockSprite({ x: 50, y: 50, displayWidth: 100, displayHeight: 150 }),
+    );
+    return visual;
+  }
+
+  it("does not throw when the graphics object is missing", () => {
     renderer.graphics = null as unknown as Phaser.GameObjects.Graphics;
 
-    // Act & Assert
     expect(() => renderer.update(null, false, false)).not.toThrow();
   });
 
-  it("clears graphics and returns early when dragging", () => {
-    // Act
+  it("clears the highlight and draws nothing while dragging", () => {
     renderer.update(null, false, true);
 
-    // Assert
-    expect(mockGraphics.clear).toHaveBeenCalled();
-    expect(mockGraphics.strokeRoundedRect).not.toHaveBeenCalled();
+    expect(graphics.clear).toHaveBeenCalled();
+    expect(graphics.strokeRoundedRect).not.toHaveBeenCalled();
   });
 
-  it("highlights stock background if stock is empty and stock background is hovered", () => {
-    // Arrange
-    gameModel.stock.clear(); // Empty the stock
+  it("highlights the stock background when the empty stock is hovered", () => {
+    gameModel.stock.clear();
 
-    // Act
     renderer.update(null, true, false);
 
-    // Assert
-    expect(mockGraphics.clear).toHaveBeenCalled();
-    expect(mockGraphics.lineStyle).toHaveBeenCalledWith(9 * 1.5, 0xebef9b, 0.9);
-    expect(mockGraphics.strokeRoundedRect).toHaveBeenCalledWith(
+    expect(graphics.lineStyle).toHaveBeenCalledWith(
+      9 * SCALE_FACTOR,
+      0xebef9b,
+      0.9,
+    );
+    expect(graphics.strokeRoundedRect).toHaveBeenCalledWith(
       20,
       20,
       100,
       150,
-      12 * 1.5,
+      12 * SCALE_FACTOR,
     );
   });
 
-  it("does not highlight stock background if stock background is hovered but stock is not empty", () => {
-    // Act
+  it("does not highlight the stock background when the stock is not empty", () => {
     renderer.update(null, true, false);
 
-    // Assert
-    expect(mockGraphics.clear).toHaveBeenCalled();
-    expect(mockGraphics.strokeRoundedRect).not.toHaveBeenCalled();
+    expect(graphics.strokeRoundedRect).not.toHaveBeenCalled();
   });
 
-  it("does not highlight empty stock background if sprite is inactive", () => {
-    // Arrange
+  it("does not highlight the empty stock background when its sprite is inactive", () => {
     gameModel.stock.clear();
-    mockBoardScene.stockPile.sprite.active = false;
+    stockSprite.active = false;
 
-    // Act
     renderer.update(null, true, false);
 
-    // Assert
-    expect(mockGraphics.clear).toHaveBeenCalled();
-    expect(mockGraphics.strokeRoundedRect).not.toHaveBeenCalled();
+    expect(graphics.strokeRoundedRect).not.toHaveBeenCalled();
   });
 
-  it("does nothing if no card is hovered", () => {
-    // Act
+  it("draws nothing when no card is hovered", () => {
     renderer.update(null, false, false);
 
-    // Assert
-    expect(mockGraphics.clear).toHaveBeenCalled();
-    expect(mockGraphics.strokeRoundedRect).not.toHaveBeenCalled();
+    expect(graphics.strokeRoundedRect).not.toHaveBeenCalled();
   });
 
-  it("does nothing if hovered card is not interactable", () => {
-    // Arrange
-    // Grab a face-down card from tableau 1 (index 0 is face down in standard game setup)
+  it("does not highlight a hovered card that is not interactable", () => {
     const faceDownCard = gameModel.tableaus[1].getCards()[0];
-    expect(gameModel.isCardInteractable(faceDownCard)).toBe(false);
 
-    const mockSprite = {
-      active: true,
-      displayWidth: 100,
-      displayHeight: 150,
-      x: 50,
-      y: 50,
-    };
-    const visual = new PlayingCardVisual(faceDownCard);
-    visual.sprite = mockSprite as unknown as Phaser.GameObjects.Sprite;
+    renderer.update(hoveredVisual(faceDownCard), false, false);
 
-    // Act
-    renderer.update(visual, false, false);
-
-    // Assert
-    expect(mockGraphics.clear).toHaveBeenCalled();
-    expect(mockGraphics.strokeRoundedRect).not.toHaveBeenCalled();
+    expect(graphics.strokeRoundedRect).not.toHaveBeenCalled();
   });
 
-  it("does nothing if hovered card sprite is inactive", () => {
-    // Arrange
-    // Grab an interactable card (e.g. face up top card in tableau 0)
+  it("does not highlight a hovered card whose sprite is inactive", () => {
     const interactableCard = gameModel.tableaus[0].getCards()[0];
-    expect(gameModel.isCardInteractable(interactableCard)).toBe(true);
-
-    const mockSprite = {
-      active: false,
-      displayWidth: 100,
-      displayHeight: 150,
-      x: 50,
-      y: 50,
-    };
     const visual = new PlayingCardVisual(interactableCard);
-    visual.sprite = mockSprite as unknown as Phaser.GameObjects.Sprite;
+    visual.sprite = asSprite(
+      createMockSprite({
+        x: 50,
+        y: 50,
+        active: false,
+        displayWidth: 100,
+        displayHeight: 150,
+      }),
+    );
 
-    // Act
     renderer.update(visual, false, false);
 
-    // Assert
-    expect(mockGraphics.clear).toHaveBeenCalled();
-    expect(mockGraphics.strokeRoundedRect).not.toHaveBeenCalled();
+    expect(graphics.strokeRoundedRect).not.toHaveBeenCalled();
   });
 
-  it("draws highlight border for an interactable active hovered card", () => {
-    // Arrange
+  it("draws a highlight border around an interactable, active hovered card", () => {
     const interactableCard = gameModel.tableaus[0].getCards()[0];
-    expect(gameModel.isCardInteractable(interactableCard)).toBe(true);
 
-    const mockSprite = {
-      active: true,
-      displayWidth: 100,
-      displayHeight: 150,
-      x: 50,
-      y: 50,
-    };
-    const visual = new PlayingCardVisual(interactableCard);
-    visual.sprite = mockSprite as unknown as Phaser.GameObjects.Sprite;
+    renderer.update(hoveredVisual(interactableCard), false, false);
 
-    // Act
-    renderer.update(visual, false, false);
-
-    // Assert
-    expect(mockGraphics.clear).toHaveBeenCalled();
-    expect(mockGraphics.lineStyle).toHaveBeenCalledWith(9 * 1.5, 0xebef9b, 0.9);
-    expect(mockGraphics.strokeRoundedRect).toHaveBeenCalledWith(
+    expect(graphics.lineStyle).toHaveBeenCalledWith(
+      9 * SCALE_FACTOR,
+      0xebef9b,
+      0.9,
+    );
+    expect(graphics.strokeRoundedRect).toHaveBeenCalledWith(
       50,
       50,
       100,
       150,
-      12 * 1.5,
+      12 * SCALE_FACTOR,
     );
   });
 });

--- a/test/game/render/scene/board/input/board_input_manager.spec.ts
+++ b/test/game/render/scene/board/input/board_input_manager.spec.ts
@@ -1,613 +1,349 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
-import * as Phaser from "phaser";
 import { BoardInputManager } from "@/game/render/scene/board/input/board_input_manager";
 import { SolitaireGame } from "@/game/model/game/solitaire_game";
 import { PlayingCardVisual } from "@/game/render/visual/card/playing_card_visual";
 import { StockPileVisual } from "@/game/render/visual/pile/stock_pile_visual";
+import { WastePileVisual } from "@/game/render/visual/pile/waste_pile_visual";
 import { TableauPileVisual } from "@/game/render/visual/pile/tableau_pile_visual";
 import { FoundationPileVisual } from "@/game/render/visual/pile/foundation_pile_visual";
-import { BoardScene } from "@/game/render/scene/board/board_scene";
+import { BoardScene, PileVisual } from "@/game/render/scene/board/board_scene";
+import {
+  asSprite,
+  createMockInput,
+  createMockSprite,
+  MockInput,
+  MockSprite,
+} from "@test/support/phaser_mocks";
 
-// Mock phaser entirely
-vi.mock("phaser", () => {
-  return {
-    Scene: class MockScene {},
-    Geom: {
-      Rectangle: Object.assign(
-        class MockRectangle {
-          constructor(
-            public x = 0,
-            public y = 0,
-            public width = 0,
-            public height = 0,
-          ) {}
-        },
-        {
-          Intersection: (rect1: any, rect2: any, out: any) => {
-            const x5 = Math.max(rect1.x, rect2.x);
-            const y5 = Math.max(rect1.y, rect2.y);
-            const x6 = Math.min(rect1.x + rect1.width, rect2.x + rect2.width);
-            const y6 = Math.min(rect1.y + rect1.height, rect2.y + rect2.height);
-
-            if (x5 >= x6 || y5 >= y6) {
-              out.x = 0;
-              out.y = 0;
-              out.width = 0;
-              out.height = 0;
-            } else {
-              out.x = x5;
-              out.y = y5;
-              out.width = x6 - x5;
-              out.height = y6 - y5;
-            }
-            return out;
-          },
-        },
-      ),
-    },
-  };
+// The source computes drop overlaps with Phaser.Geom.Rectangle. Provide just
+// that geometry so the real phaser module (which needs a browser environment)
+// is not required in the node test environment.
+vi.mock("phaser", async () => {
+  const mocks = await import("@test/support/phaser_mocks");
+  return mocks.geomPhaserMock();
 });
 
 describe("BoardInputManager", () => {
-  let mockSceneListeners: { [event: string]: Function };
-  let mockBoardScene: BoardScene;
   let gameModel: SolitaireGame;
+  let input: MockInput;
+  let stockPile: StockPileVisual;
+  let tableauPiles: TableauPileVisual[];
+  let foundationPiles: FoundationPileVisual[];
+  let getPileVisualById: ReturnType<typeof vi.fn>;
+  let updateVisualLayout: ReturnType<typeof vi.fn>;
+  let boardScene: BoardScene;
   let inputManager: BoardInputManager;
 
   beforeEach(() => {
-    mockSceneListeners = {};
     gameModel = new SolitaireGame();
     gameModel.startNewGame();
 
-    const mockLayoutManager = {
-      getScaleFactor: () => 1.0,
-      updateVisualLayout: vi.fn(),
-    };
+    input = createMockInput();
+    stockPile = new StockPileVisual(gameModel.stock);
+    const wastePile = new WastePileVisual(gameModel.waste);
+    foundationPiles = gameModel.foundations.map(
+      (f) => new FoundationPileVisual(f),
+    );
+    tableauPiles = gameModel.tableaus.map((t) => new TableauPileVisual(t));
 
-    mockBoardScene = {
-      input: {
-        on: vi.fn().mockImplementation((event: string, cb: Function) => {
-          mockSceneListeners[event] = cb;
-        }),
-        setDraggable: vi.fn(),
-      },
+    getPileVisualById = vi.fn((pileId: string): PileVisual | null => {
+      if (pileId === "stock") return stockPile;
+      if (pileId === "waste") return wastePile;
+      if (pileId.startsWith("tableau-")) {
+        return tableauPiles[Number(pileId.split("-")[1])];
+      }
+      if (pileId.startsWith("foundation-")) {
+        return foundationPiles[Number(pileId.split("-")[1])];
+      }
+      return null;
+    });
+    updateVisualLayout = vi.fn();
+
+    boardScene = {
+      input,
       gameModel,
-      stockPile: new StockPileVisual(gameModel.stock),
-      wastePile: new StockPileVisual(gameModel.waste),
-      foundationPiles: [
-        new FoundationPileVisual(gameModel.foundations[0]),
-        new FoundationPileVisual(gameModel.foundations[1]),
-        new FoundationPileVisual(gameModel.foundations[2]),
-        new FoundationPileVisual(gameModel.foundations[3]),
-      ],
-      tableauPiles: [
-        new TableauPileVisual(gameModel.tableaus[0]),
-        new TableauPileVisual(gameModel.tableaus[1]),
-        new TableauPileVisual(gameModel.tableaus[2]),
-        new TableauPileVisual(gameModel.tableaus[3]),
-        new TableauPileVisual(gameModel.tableaus[4]),
-        new TableauPileVisual(gameModel.tableaus[5]),
-        new TableauPileVisual(gameModel.tableaus[6]),
-      ],
-      getPileVisualById: vi.fn().mockImplementation((pileId: string) => {
-        if (pileId === "stock") return mockBoardScene.stockPile;
-        if (pileId === "waste") return mockBoardScene.wastePile;
-        if (pileId.startsWith("tableau-")) {
-          const index = parseInt(pileId.split("-")[1], 10);
-          return mockBoardScene.tableauPiles[index];
-        }
-        if (pileId.startsWith("foundation-")) {
-          const index = parseInt(pileId.split("-")[1], 10);
-          return mockBoardScene.foundationPiles[index];
-        }
-        return null;
-      }),
+      stockPile,
+      wastePile,
+      foundationPiles,
+      tableauPiles,
+      getPileVisualById,
       updateHighlightBorder: vi.fn(),
-      getLayoutManager: () => mockLayoutManager,
+      getLayoutManager: () => ({
+        getScaleFactor: () => 1.0,
+        updateVisualLayout,
+      }),
     } as unknown as BoardScene;
 
-    // Helper to assign a mock sprite to the background of stock Pile
-    mockBoardScene.stockPile.sprite = {
-      active: true,
-      displayWidth: 220,
-      displayHeight: 307,
-      x: 40,
-      y: 40,
-    } as unknown as Phaser.GameObjects.Sprite;
+    stockPile.sprite = asSprite(
+      createMockSprite({ x: 40, y: 40, displayWidth: 220, displayHeight: 307 }),
+    );
 
-    inputManager = new BoardInputManager(mockBoardScene);
+    inputManager = new BoardInputManager(boardScene);
   });
 
-  describe("Drag Listener Registration", () => {
-    it("registers drag event listeners on input system", () => {
-      // Act
-      inputManager.registerDragListeners();
+  /** Registers card listeners for a fresh sprite bound to the given card. */
+  function listenTo(card = gameModel.tableaus[0].getCards()[0]): {
+    sprite: MockSprite;
+    visual: PlayingCardVisual;
+  } {
+    const visual = new PlayingCardVisual(card);
+    const sprite = createMockSprite();
+    visual.sprite = asSprite(sprite);
+    inputManager.registerCardListeners(asSprite(sprite), visual);
+    return { sprite, visual };
+  }
 
-      // Assert
-      expect(mockBoardScene.input.on).toHaveBeenCalledWith(
-        "dragstart",
-        expect.any(Function),
-      );
-      expect(mockBoardScene.input.on).toHaveBeenCalledWith(
-        "drag",
-        expect.any(Function),
-      );
-      expect(mockBoardScene.input.on).toHaveBeenCalledWith(
-        "dragend",
-        expect.any(Function),
-      );
-    });
-  });
+  describe("card hover", () => {
+    it("marks a card as hovered on pointerover", () => {
+      const { sprite, visual } = listenTo();
 
-  describe("Card Interaction Listeners", () => {
-    let mockSprite: any;
-    let visualCard: PlayingCardVisual;
+      sprite.emit("pointerover");
 
-    beforeEach(() => {
-      const card = gameModel.tableaus[0].getCards()[0];
-      visualCard = new PlayingCardVisual(card);
-      // Create mock sprite using the mocked phaser module via direct construction
-      mockSprite = {
-        on: vi.fn(),
-        emit: vi.fn(),
-      };
-      visualCard.sprite = mockSprite;
-      inputManager.registerCardListeners(mockSprite, visualCard);
+      expect(inputManager.hoveredCardVisual).toBe(visual);
     });
 
-    it("registers pointerover, pointerout, pointerdown on sprite", () => {
-      expect(mockSprite.on).toHaveBeenCalledWith(
-        "pointerover",
-        expect.any(Function),
-      );
-      expect(mockSprite.on).toHaveBeenCalledWith(
-        "pointerout",
-        expect.any(Function),
-      );
-      expect(mockSprite.on).toHaveBeenCalledWith(
-        "pointerdown",
-        expect.any(Function),
-      );
-    });
+    it("clears the hovered card on pointerout when it is the hovered card", () => {
+      const { sprite, visual } = listenTo();
+      inputManager.hoveredCardVisual = visual;
 
-    it("pointerover sets hoveredCardVisual and updates highlight", () => {
-      // Retrieve the callback passed to 'on' for 'pointerover'
-      const pointerOverCb = mockSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerover",
-      )[1];
+      sprite.emit("pointerout");
 
-      // Act
-      pointerOverCb();
-
-      // Assert
-      expect(inputManager.hoveredCardVisual).toBe(visualCard);
-      expect(mockBoardScene.updateHighlightBorder).toHaveBeenCalled();
-    });
-
-    it("pointerout clears hoveredCardVisual if it matches", () => {
-      // Set initial hover state
-      inputManager.hoveredCardVisual = visualCard;
-      const pointerOutCb = mockSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerout",
-      )[1];
-
-      // Act
-      pointerOutCb();
-
-      // Assert
       expect(inputManager.hoveredCardVisual).toBeNull();
-      expect(mockBoardScene.updateHighlightBorder).toHaveBeenCalled();
     });
 
-    it("pointerout does not clear hoveredCardVisual if it is a different card", () => {
-      // Arrange
-      const anotherCard = gameModel.tableaus[1].getCards()[0];
-      const anotherVisual = new PlayingCardVisual(anotherCard);
-      inputManager.hoveredCardVisual = anotherVisual;
-      const pointerOutCb = mockSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerout",
-      )[1];
+    it("leaves a different hovered card untouched on pointerout", () => {
+      const { sprite } = listenTo();
+      const otherVisual = new PlayingCardVisual(
+        gameModel.tableaus[1].getCards()[0],
+      );
+      inputManager.hoveredCardVisual = otherVisual;
 
-      // Act
-      pointerOutCb();
+      sprite.emit("pointerout");
 
-      // Assert
-      expect(inputManager.hoveredCardVisual).toBe(anotherVisual);
+      expect(inputManager.hoveredCardVisual).toBe(otherVisual);
     });
+  });
 
-    it("pointerdown on top stock card triggers drawing", () => {
-      // Arrange
+  describe("card pointerdown", () => {
+    it("draws from the stock when the top stock card is clicked", () => {
       const stockCards = gameModel.stock.getCards();
-      const topStockCard = stockCards[stockCards.length - 1];
-      const stockVisual = new PlayingCardVisual(topStockCard);
-      const drawSprite: any = { on: vi.fn() };
-      stockVisual.sprite = drawSprite;
-      inputManager.registerCardListeners(drawSprite, stockVisual);
-
-      const pointerDownCb = drawSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerdown",
-      )[1];
+      const { sprite } = listenTo(stockCards[stockCards.length - 1]);
       const initialStockSize = gameModel.stock.getCards().length;
 
-      // Act
-      pointerDownCb();
+      sprite.emit("pointerdown");
 
-      // Assert
       expect(gameModel.stock.getCards().length).toBe(initialStockSize - 3);
       expect(gameModel.waste.getCards().length).toBe(3);
     });
 
-    it("pointerdown on non-top stock card does not trigger drawing", () => {
-      // Arrange
-      const stockCards = gameModel.stock.getCards();
-      const nonTopStockCard = stockCards[0];
-      const stockVisual = new PlayingCardVisual(nonTopStockCard);
-      const drawSprite: any = { on: vi.fn() };
-      stockVisual.sprite = drawSprite;
-      inputManager.registerCardListeners(drawSprite, stockVisual);
-
-      const pointerDownCb = drawSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerdown",
-      )[1];
+    it("does not draw when a non-top stock card is clicked", () => {
+      const { sprite } = listenTo(gameModel.stock.getCards()[0]);
       const initialStockSize = gameModel.stock.getCards().length;
 
-      // Act
-      pointerDownCb();
+      sprite.emit("pointerdown");
 
-      // Assert
       expect(gameModel.stock.getCards().length).toBe(initialStockSize);
       expect(gameModel.waste.getCards().length).toBe(0);
     });
 
-    it("pointerdown throws error if card is not in any pile", () => {
-      // Arrange
+    it("does not draw from the stock when a tableau card is clicked", () => {
+      const { sprite } = listenTo();
+      const initialStockSize = gameModel.stock.getCards().length;
+
+      sprite.emit("pointerdown");
+
+      expect(gameModel.stock.getCards().length).toBe(initialStockSize);
+      expect(gameModel.waste.getCards().length).toBe(0);
+    });
+
+    it("throws when the clicked card is in no pile", () => {
       const card = gameModel.tableaus[0].getCards()[0];
-      const ghostVisual = new PlayingCardVisual(card);
-      const ghostSprite: any = { on: vi.fn() };
-      ghostVisual.sprite = ghostSprite;
-      // Remove card from game
+      const { sprite } = listenTo(card);
       gameModel.tableaus[0].removeCard(card);
 
-      inputManager.registerCardListeners(ghostSprite, ghostVisual);
-      const pointerDownCb = ghostSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerdown",
-      )[1];
-
-      // Act & Assert
-      expect(() => pointerDownCb()).toThrow(/is not in a pile/);
-    });
-
-    it("pointerdown on a tableau card does not trigger stock card drawing", () => {
-      const initialStockSize = gameModel.stock.getCards().length;
-      const pointerDownCb = mockSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerdown",
-      )[1];
-
-      // Act
-      pointerDownCb();
-
-      // Assert
-      expect(gameModel.stock.getCards().length).toBe(initialStockSize);
-      expect(gameModel.waste.getCards().length).toBe(0);
+      expect(() => sprite.emit("pointerdown")).toThrow(/is not in a pile/);
     });
   });
 
-  describe("Stock Background Interaction", () => {
-    let mockSprite: any;
+  describe("stock background", () => {
+    let stockBackground: MockSprite;
 
     beforeEach(() => {
-      mockSprite = {
-        on: vi.fn(),
-      };
-      inputManager.registerStockBackgroundListeners(mockSprite);
+      stockBackground = createMockSprite();
+      inputManager.registerStockBackgroundListeners(asSprite(stockBackground));
     });
 
-    it("registers pointerdown, pointerover, and pointerout on stock background", () => {
-      expect(mockSprite.on).toHaveBeenCalledWith(
-        "pointerdown",
-        expect.any(Function),
-      );
-      expect(mockSprite.on).toHaveBeenCalledWith(
-        "pointerover",
-        expect.any(Function),
-      );
-      expect(mockSprite.on).toHaveBeenCalledWith(
-        "pointerout",
-        expect.any(Function),
-      );
-    });
-
-    it("pointerdown recycles stock if stock is empty", () => {
-      // Arrange
+    it("recycles the waste when the empty stock background is clicked", () => {
       gameModel.stock.clear();
       const card = gameModel.getCardById("card-clubs-ace")!;
       gameModel.getPileContainingCard(card.id)?.removeCard(card);
       gameModel.waste.addCard(card);
-      const pointerDownCb = mockSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerdown",
-      )[1];
 
-      // Act
-      pointerDownCb();
+      stockBackground.emit("pointerdown");
 
-      // Assert
       expect(gameModel.stock.getCards().length).toBe(1);
       expect(gameModel.waste.getCards().length).toBe(0);
     });
 
-    it("pointerdown does nothing on stock background if stock is not empty", () => {
-      // Arrange
-      const pointerDownCb = mockSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerdown",
-      )[1];
+    it("does nothing when the stock is not empty", () => {
       const initialStockSize = gameModel.stock.getCards().length;
 
-      // Act
-      pointerDownCb();
+      stockBackground.emit("pointerdown");
 
-      // Assert
       expect(gameModel.stock.getCards().length).toBe(initialStockSize);
     });
 
-    it("pointerover sets isStockBackgroundHovered to true", () => {
-      // Arrange
-      const pointerOverCb = mockSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerover",
-      )[1];
+    it("marks the stock background hovered on pointerover", () => {
+      stockBackground.emit("pointerover");
 
-      // Act
-      pointerOverCb();
-
-      // Assert
       expect(inputManager.isStockBackgroundHovered).toBe(true);
-      expect(mockBoardScene.updateHighlightBorder).toHaveBeenCalled();
     });
 
-    it("pointerout sets isStockBackgroundHovered to false", () => {
-      // Arrange
+    it("clears the stock background hover on pointerout", () => {
       inputManager.isStockBackgroundHovered = true;
-      const pointerOutCb = mockSprite.on.mock.calls.find(
-        (call: any) => call[0] === "pointerout",
-      )[1];
 
-      // Act
-      pointerOutCb();
+      stockBackground.emit("pointerout");
 
-      // Assert
       expect(inputManager.isStockBackgroundHovered).toBe(false);
-      expect(mockBoardScene.updateHighlightBorder).toHaveBeenCalled();
     });
   });
 
-  describe("Drag State Transitions", () => {
+  describe("dragging", () => {
+    let sprite: MockSprite;
     let cardVisual: PlayingCardVisual;
-    let sprite: Phaser.GameObjects.Sprite;
-    let mockSpriteFn: (x?: number, y?: number) => Phaser.GameObjects.Sprite;
 
     beforeEach(() => {
-      const card = gameModel.tableaus[0].getCards()[0];
-      cardVisual = new PlayingCardVisual(card);
-
-      mockSpriteFn = (x = 0, y = 0) => {
-        const dataMap = new Map<string, any>();
-        return {
-          x,
-          y,
-          setPosition: vi.fn().mockImplementation(function (
-            this: any,
-            nx: number,
-            ny: number,
-          ) {
-            this.x = nx;
-            this.y = ny;
-            return this;
-          }),
-          setDepth: vi.fn(),
-          getData: (key: string) => dataMap.get(key),
-          setData: (key: string, val: any) => dataMap.set(key, val),
-          displayWidth: 100,
-          displayHeight: 150,
-        } as unknown as Phaser.GameObjects.Sprite;
-      };
-
-      sprite = mockSpriteFn(100, 150);
+      cardVisual = new PlayingCardVisual(gameModel.tableaus[0].getCards()[0]);
+      sprite = createMockSprite({ x: 100, y: 150 });
       sprite.setData("cardVisual", cardVisual);
-      cardVisual.sprite = sprite;
-
-      mockBoardScene.tableauPiles[0].playingCardVisuals = [cardVisual];
-
+      cardVisual.sprite = asSprite(sprite);
+      tableauPiles[0].playingCardVisuals = [cardVisual];
       inputManager.registerDragListeners();
     });
 
-    it("onDragStart initializes dragged stack and offsets", () => {
-      // Act
-      mockSceneListeners["dragstart"]({}, sprite);
+    it("captures the dragged stack and lifts it on dragstart", () => {
+      input.emit("dragstart", {}, asSprite(sprite));
 
-      // Assert
       expect(inputManager.draggedStack).toEqual([cardVisual]);
       expect(inputManager.draggedStackOffsets).toEqual([{ x: 0, y: 0 }]);
-      expect(sprite.setDepth).toHaveBeenCalledWith(1000);
-      expect(mockBoardScene.updateHighlightBorder).toHaveBeenCalled();
+      expect(sprite.depth).toBe(1000);
     });
 
-    it("onDragStart returns early if sprite lacks cardVisual data", () => {
-      // Arrange
-      const dummySprite = {
-        getData: () => null,
-      } as unknown as Phaser.GameObjects.Sprite;
+    it("does not start a drag when the sprite has no card visual", () => {
+      const dummy = createMockSprite();
 
-      // Act
-      mockSceneListeners["dragstart"]({}, dummySprite);
+      input.emit("dragstart", {}, asSprite(dummy));
 
-      // Assert
       expect(inputManager.draggedStack).toEqual([]);
     });
 
-    it("onDragStart returns early if card is not in any model pile", () => {
-      // Arrange
-      const card = cardVisual.playingCard;
-      gameModel.tableaus[0].removeCard(card);
+    it("does not start a drag when the card is in no model pile", () => {
+      gameModel.tableaus[0].removeCard(cardVisual.playingCard);
 
-      // Act
-      mockSceneListeners["dragstart"]({}, sprite);
+      input.emit("dragstart", {}, asSprite(sprite));
 
-      // Assert
       expect(inputManager.draggedStack).toEqual([]);
     });
 
-    it("onDragStart returns early if pile visual is not found", () => {
-      // Arrange
-      mockBoardScene.getPileVisualById.mockReturnValue(null);
+    it("does not start a drag when the pile visual is not found", () => {
+      getPileVisualById.mockReturnValue(null);
 
-      // Act
-      mockSceneListeners["dragstart"]({}, sprite);
+      input.emit("dragstart", {}, asSprite(sprite));
 
-      // Assert
       expect(inputManager.draggedStack).toEqual([]);
     });
 
-    it("onDragStart returns early if card visual is not in pile visual array", () => {
-      // Arrange
-      mockBoardScene.tableauPiles[0].playingCardVisuals = [];
+    it("does not start a drag when the card visual is not in the pile visual", () => {
+      tableauPiles[0].playingCardVisuals = [];
 
-      // Act
-      mockSceneListeners["dragstart"]({}, sprite);
+      input.emit("dragstart", {}, asSprite(sprite));
 
-      // Assert
       expect(inputManager.draggedStack).toEqual([]);
     });
 
-    it("onDrag updates position of dragged stack cards relative to primary card", () => {
-      // Arrange
-      // Add multiple cards to tableau
-      const card2 = gameModel.tableaus[0].getCards()[0]; // Just a dummy
-      const cardVisual2 = new PlayingCardVisual(card2);
-      const sprite2 = mockSpriteFn(100, 180);
-      cardVisual2.sprite = sprite2;
-      mockBoardScene.tableauPiles[0].playingCardVisuals = [
-        cardVisual,
-        cardVisual2,
-      ];
+    it("moves the whole stack relative to the primary card on drag", () => {
+      const followerVisual = new PlayingCardVisual(
+        gameModel.tableaus[0].getCards()[0],
+      );
+      const followerSprite = createMockSprite({ x: 100, y: 180 });
+      followerVisual.sprite = asSprite(followerSprite);
+      tableauPiles[0].playingCardVisuals = [cardVisual, followerVisual];
+      input.emit("dragstart", {}, asSprite(sprite));
 
-      mockSceneListeners["dragstart"]({}, sprite);
+      input.emit("drag", {}, asSprite(sprite), 200, 300);
 
-      // Act
-      mockSceneListeners["drag"]({}, sprite, 200, 300);
-
-      // Assert
-      expect(sprite.setPosition).toHaveBeenCalledWith(200, 300);
-      expect(sprite2.setPosition).toHaveBeenCalledWith(200, 330);
+      expect({ x: sprite.x, y: sprite.y }).toEqual({ x: 200, y: 300 });
+      expect({ x: followerSprite.x, y: followerSprite.y }).toEqual({
+        x: 200,
+        y: 330,
+      });
     });
 
-    it("onDrag returns early if draggedStack is empty", () => {
-      // Act
-      mockSceneListeners["drag"]({}, sprite, 200, 300);
+    it("ignores drag events when nothing is being dragged", () => {
+      input.emit("drag", {}, asSprite(sprite), 200, 300);
 
-      // Assert
-      expect(sprite.setPosition).not.toHaveBeenCalled();
+      expect({ x: sprite.x, y: sprite.y }).toEqual({ x: 100, y: 150 });
     });
 
-    it("onDragEnd returns early if draggedStack is empty", () => {
-      // Act
-      mockSceneListeners["dragend"]({}, sprite);
+    it("ignores dragend when nothing is being dragged", () => {
+      input.emit("dragend", {}, asSprite(sprite));
 
-      // Assert
-      expect(
-        mockBoardScene.getLayoutManager().updateVisualLayout,
-      ).not.toHaveBeenCalled();
+      expect(updateVisualLayout).not.toHaveBeenCalled();
     });
 
-    it("onDragEnd returns early if visual data is missing", () => {
-      // Arrange
-      mockSceneListeners["dragstart"]({}, sprite);
-      const dummySprite: any = { getData: () => null };
+    it("snaps back on dragend when the sprite has no card visual", () => {
+      input.emit("dragstart", {}, asSprite(sprite));
+      const dummy = createMockSprite();
 
-      // Act
-      mockSceneListeners["dragend"]({}, dummySprite);
+      input.emit("dragend", {}, asSprite(dummy));
 
-      // Assert
       expect(inputManager.draggedStack).toEqual([]);
-      expect(
-        mockBoardScene.getLayoutManager().updateVisualLayout,
-      ).toHaveBeenCalled();
+      expect(updateVisualLayout).toHaveBeenCalled();
     });
 
-    it("onDragEnd moves card if dropped on target and valid", () => {
-      // Arrange
-      // Let's set up the target pile visual to overlap
-      const targetPile = mockBoardScene.tableauPiles[1];
+    it("moves the card when dropped on a valid target pile", () => {
+      const targetPile = tableauPiles[1];
       targetPile.position = { x: 150, y: 150 };
-      targetPile.playingCardVisuals = []; // Empty
-
-      // Position the sprite to overlap with target pile (x: 150, y: 150)
-      sprite.x = 150;
-      sprite.y = 150;
-      sprite.displayWidth = 100;
-      sprite.displayHeight = 150;
-
-      mockSceneListeners["dragstart"]({}, sprite);
-
+      targetPile.playingCardVisuals = [];
+      sprite.setPosition(150, 150);
       const moveSpy = vi
         .spyOn(gameModel, "moveCardToPile")
         .mockReturnValue(true);
+      input.emit("dragstart", {}, asSprite(sprite));
 
-      // Act
-      mockSceneListeners["dragend"]({}, sprite);
+      input.emit("dragend", {}, asSprite(sprite));
 
-      // Assert
       expect(moveSpy).toHaveBeenCalledWith(
         cardVisual.playingCard.id,
         targetPile.value.id,
       );
       expect(inputManager.draggedStack).toEqual([]);
-      moveSpy.mockRestore();
     });
 
-    it("onDragEnd snaps card back to layout if move is invalid", () => {
-      // Arrange
-      const targetPile = mockBoardScene.tableauPiles[1];
+    it("snaps back when dropped on a target but the move is rejected", () => {
+      const targetPile = tableauPiles[1];
       targetPile.position = { x: 150, y: 150 };
       targetPile.playingCardVisuals = [];
+      sprite.setPosition(150, 150);
+      vi.spyOn(gameModel, "moveCardToPile").mockReturnValue(false);
+      input.emit("dragstart", {}, asSprite(sprite));
 
-      sprite.x = 150;
-      sprite.y = 150;
+      input.emit("dragend", {}, asSprite(sprite));
 
-      mockSceneListeners["dragstart"]({}, sprite);
-
-      const moveSpy = vi
-        .spyOn(gameModel, "moveCardToPile")
-        .mockReturnValue(false);
-
-      // Act
-      mockSceneListeners["dragend"]({}, sprite);
-
-      // Assert
-      expect(moveSpy).toHaveBeenCalled();
-      expect(
-        mockBoardScene.getLayoutManager().updateVisualLayout,
-      ).toHaveBeenCalled();
+      expect(updateVisualLayout).toHaveBeenCalled();
       expect(inputManager.draggedStack).toEqual([]);
-      moveSpy.mockRestore();
     });
 
-    it("onDragEnd does not find a target pile if there is no overlap", () => {
-      // Arrange
-      sprite.x = 9000;
-      sprite.y = 9000;
-
-      mockSceneListeners["dragstart"]({}, sprite);
+    it("snaps back without moving when dropped away from every pile", () => {
+      sprite.setPosition(9000, 9000);
       const moveSpy = vi.spyOn(gameModel, "moveCardToPile");
+      input.emit("dragstart", {}, asSprite(sprite));
 
-      // Act
-      mockSceneListeners["dragend"]({}, sprite);
+      input.emit("dragend", {}, asSprite(sprite));
 
-      // Assert
       expect(moveSpy).not.toHaveBeenCalled();
-      expect(
-        mockBoardScene.getLayoutManager().updateVisualLayout,
-      ).toHaveBeenCalled();
+      expect(updateVisualLayout).toHaveBeenCalled();
       expect(inputManager.draggedStack).toEqual([]);
-      moveSpy.mockRestore();
     });
   });
 });

--- a/test/game/render/scene/board/layout/board_layout_manager.spec.ts
+++ b/test/game/render/scene/board/layout/board_layout_manager.spec.ts
@@ -1,278 +1,164 @@
-import { vi } from "vitest";
+import { vi, describe, it, expect, beforeEach } from "vitest";
 import { BoardLayoutManager } from "@/game/render/scene/board/layout/board_layout_manager";
 import { Visual } from "@/game/render/visual/visual";
 import { CardPile } from "@/game/model/card/card_pile";
 import { BoardScene } from "@/game/render/scene/board/board_scene";
-
-function createMockSprite() {
-  const sprite = {
-    x: 0,
-    y: 0,
-    scale: 1,
-    originX: 0,
-    originY: 0,
-    depth: 0,
-    setPosition: vi.fn().mockImplementation(function (
-      this: any,
-      x: number,
-      y: number,
-    ) {
-      this.x = x;
-      this.y = y;
-      return this;
-    }),
-    setScale: vi.fn().mockImplementation(function (this: any, scale: number) {
-      this.scale = scale;
-      return this;
-    }),
-    setOrigin: vi.fn().mockImplementation(function (
-      this: any,
-      x: number,
-      y: number,
-    ) {
-      this.originX = x;
-      this.originY = y;
-      return this;
-    }),
-    setDepth: vi.fn().mockImplementation(function (this: any, depth: number) {
-      this.depth = depth;
-      return this;
-    }),
-  };
-  return sprite;
-}
+import { asSprite, createMockSprite } from "@test/support/phaser_mocks";
 
 describe("BoardLayoutManager", () => {
-  it("maps positions for each pile on the board correctly", () => {
-    // Mock the BoardScene with piles that have Visual wrappers
-    const mockBoardScene = {
-      stockPile: new Visual(new CardPile()),
-      wastePile: new Visual(new CardPile()),
-      foundationPiles: [
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-      ],
-      tableauPiles: [
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-        new Visual(new CardPile()),
-      ],
+  describe("createInitialLayout", () => {
+    let scene: {
+      stockPile: Visual;
+      wastePile: Visual;
+      foundationPiles: Visual[];
+      tableauPiles: Visual[];
     };
 
-    const layoutManager = new BoardLayoutManager(
-      mockBoardScene as unknown as BoardScene,
-    );
-    layoutManager.createInitialLayout();
-
-    // Verify Stock Pile position (Column 0, Top Row)
-    // paddingX (40) + 0 * (221 + 30) = 40
-    // topRowY = 40
-    expect(mockBoardScene.stockPile.position).toEqual({ x: 40, y: 40 });
-
-    // Verify Waste Pile position (Column 1, Top Row)
-    // paddingX (40) + 1 * (221 + 30) = 291
-    expect(mockBoardScene.wastePile.position).toEqual({ x: 291, y: 40 });
-
-    // Verify Foundation Piles positions (Columns 3 to 6, Top Row)
-    // Col 3: 40 + 3 * 251 = 793
-    // Col 4: 40 + 4 * 251 = 1044
-    // Col 5: 40 + 5 * 251 = 1295
-    // Col 6: 40 + 6 * 251 = 1546
-    expect(mockBoardScene.foundationPiles[0].position).toEqual({
-      x: 793,
-      y: 40,
-    });
-    expect(mockBoardScene.foundationPiles[1].position).toEqual({
-      x: 1044,
-      y: 40,
-    });
-    expect(mockBoardScene.foundationPiles[2].position).toEqual({
-      x: 1295,
-      y: 40,
-    });
-    expect(mockBoardScene.foundationPiles[3].position).toEqual({
-      x: 1546,
-      y: 40,
+    beforeEach(() => {
+      scene = {
+        stockPile: new Visual(new CardPile()),
+        wastePile: new Visual(new CardPile()),
+        foundationPiles: Array.from(
+          { length: 4 },
+          () => new Visual(new CardPile()),
+        ),
+        tableauPiles: Array.from(
+          { length: 7 },
+          () => new Visual(new CardPile()),
+        ),
+      };
+      new BoardLayoutManager(
+        scene as unknown as BoardScene,
+      ).createInitialLayout();
     });
 
-    // Verify Tableau Piles positions (Columns 0 to 6, Bottom Row)
-    // bottomRowY = paddingY (40) + cardHeight (313) + gapY (40) = 393
-    expect(mockBoardScene.tableauPiles[0].position).toEqual({ x: 40, y: 393 });
-    expect(mockBoardScene.tableauPiles[1].position).toEqual({ x: 291, y: 393 });
-    expect(mockBoardScene.tableauPiles[2].position).toEqual({ x: 542, y: 393 });
-    expect(mockBoardScene.tableauPiles[3].position).toEqual({ x: 793, y: 393 });
-    expect(mockBoardScene.tableauPiles[4].position).toEqual({
-      x: 1044,
-      y: 393,
+    it("places the stock and waste piles on the top row", () => {
+      expect(scene.stockPile.position).toEqual({ x: 40, y: 40 });
+      expect(scene.wastePile.position).toEqual({ x: 291, y: 40 });
     });
-    expect(mockBoardScene.tableauPiles[5].position).toEqual({
-      x: 1295,
-      y: 393,
+
+    it("places the four foundations across the top row", () => {
+      const positions = scene.foundationPiles.map((p) => p.position);
+      expect(positions).toEqual([
+        { x: 793, y: 40 },
+        { x: 1044, y: 40 },
+        { x: 1295, y: 40 },
+        { x: 1546, y: 40 },
+      ]);
     });
-    expect(mockBoardScene.tableauPiles[6].position).toEqual({
-      x: 1546,
-      y: 393,
+
+    it("places the seven tableaus across the bottom row", () => {
+      const positions = scene.tableauPiles.map((p) => p.position);
+      expect(positions).toEqual([
+        { x: 40, y: 393 },
+        { x: 291, y: 393 },
+        { x: 542, y: 393 },
+        { x: 793, y: 393 },
+        { x: 1044, y: 393 },
+        { x: 1295, y: 393 },
+        { x: 1546, y: 393 },
+      ]);
     });
   });
 
-  it("updates visual layout and aligns sprites correctly", () => {
-    const mockStockPile = {
-      layoutPile: vi.fn(),
-      position: { x: 10, y: 20 },
-      playingCardVisuals: [
-        {
-          position: { x: 5, y: 5 },
-          sprite: createMockSprite(),
-        },
-        {
-          position: { x: 6, y: 6 },
-        },
-      ],
-    };
-    const mockWastePile = {
-      layoutPile: vi.fn(),
-      position: { x: 30, y: 40 },
-      playingCardVisuals: [],
-    };
-    const mockFoundationPile = {
-      layoutPile: vi.fn(),
-      position: { x: 50, y: 60 },
-      playingCardVisuals: [
-        {
-          position: { x: 2, y: 2 },
-          sprite: createMockSprite(),
-        },
-      ],
-    };
-    const mockTableauPile = {
-      layoutPile: vi.fn(),
-      position: { x: 70, y: 80 },
-      playingCardVisuals: [
-        {
-          position: { x: 3, y: 3 },
-          sprite: createMockSprite(),
-        },
-      ],
-    };
+  describe("updateVisualLayout", () => {
+    /** Builds a mock pile visual with the given absolute position and cards. */
+    function pile(
+      position: { x: number; y: number },
+      playingCardVisuals: {
+        position: { x: number; y: number };
+        sprite?: unknown;
+      }[],
+    ) {
+      return { layoutPile: vi.fn(), position, playingCardVisuals };
+    }
 
-    const mockBoardScene = {
-      stockPile: mockStockPile,
-      wastePile: mockWastePile,
-      foundationPiles: [mockFoundationPile],
-      tableauPiles: [mockTableauPile],
-    };
-
-    const layoutManager = new BoardLayoutManager(
-      mockBoardScene as unknown as BoardScene,
-    );
-    layoutManager.updateVisualLayout();
-
-    const stockSprite = mockStockPile.playingCardVisuals[0].sprite!;
-    expect(stockSprite.x).toBe(15);
-    expect(stockSprite.y).toBe(25);
-    expect(stockSprite.depth).toBe(0);
-
-    const foundationSprite = mockFoundationPile.playingCardVisuals[0].sprite!;
-    expect(foundationSprite.x).toBe(52);
-    expect(foundationSprite.y).toBe(62);
-    expect(foundationSprite.depth).toBe(0);
-
-    const tableauSprite = mockTableauPile.playingCardVisuals[0].sprite!;
-    expect(tableauSprite.x).toBe(73);
-    expect(tableauSprite.y).toBe(83);
-    expect(tableauSprite.depth).toBe(0);
-  });
-
-  it("scales cards and aligns coordinates correctly when viewport is smaller than default", () => {
-    const mockStockSprite = createMockSprite();
-    const mockBoardScene = {
-      scale: {
-        width: 903.5,
-        height: 475,
-      },
-      stockPile: {
-        layoutPile: vi.fn(),
-        position: { x: 0, y: 0 },
-        playingCardVisuals: [
-          {
-            position: { x: 10, y: 20 },
-            sprite: mockStockSprite,
-          },
+    it("places each card sprite at its pile position plus its relative offset", () => {
+      const stockSprite = createMockSprite();
+      const foundationSprite = createMockSprite();
+      const tableauSprite = createMockSprite();
+      const scene = {
+        stockPile: pile({ x: 10, y: 20 }, [
+          { position: { x: 5, y: 5 }, sprite: asSprite(stockSprite) },
+          { position: { x: 6, y: 6 } },
+        ]),
+        wastePile: pile({ x: 30, y: 40 }, []),
+        foundationPiles: [
+          pile({ x: 50, y: 60 }, [
+            { position: { x: 2, y: 2 }, sprite: asSprite(foundationSprite) },
+          ]),
         ],
-      },
-      wastePile: {
-        layoutPile: vi.fn(),
-        position: { x: 0, y: 0 },
-        playingCardVisuals: [],
-      },
-      foundationPiles: [],
-      tableauPiles: [],
-    };
+        tableauPiles: [
+          pile({ x: 70, y: 80 }, [
+            { position: { x: 3, y: 3 }, sprite: asSprite(tableauSprite) },
+          ]),
+        ],
+      };
 
-    const layoutManager = new BoardLayoutManager(
-      mockBoardScene as unknown as BoardScene,
-    );
-    layoutManager.createInitialLayout();
-    layoutManager.updateVisualLayout();
+      new BoardLayoutManager(
+        scene as unknown as BoardScene,
+      ).updateVisualLayout();
 
-    expect(mockBoardScene.stockPile.position).toEqual({ x: 20, y: 20 });
-    expect(mockStockSprite.x).toBe(25);
-    expect(mockStockSprite.y).toBe(30);
-    expect(mockStockSprite.scale).toBe(0.5);
-    expect(mockStockSprite.depth).toBe(0);
+      expect({
+        x: stockSprite.x,
+        y: stockSprite.y,
+        depth: stockSprite.depth,
+      }).toEqual({ x: 15, y: 25, depth: 0 });
+      expect({
+        x: foundationSprite.x,
+        y: foundationSprite.y,
+        depth: foundationSprite.depth,
+      }).toEqual({ x: 52, y: 62, depth: 0 });
+      expect({
+        x: tableauSprite.x,
+        y: tableauSprite.y,
+        depth: tableauSprite.depth,
+      }).toEqual({ x: 73, y: 83, depth: 0 });
+    });
+
+    it("scales positions and sprites down when the viewport is smaller than the default", () => {
+      const stockSprite = createMockSprite();
+      const scene = {
+        scale: { width: 903.5, height: 475 },
+        stockPile: pile({ x: 0, y: 0 }, [
+          { position: { x: 10, y: 20 }, sprite: asSprite(stockSprite) },
+        ]),
+        wastePile: pile({ x: 0, y: 0 }, []),
+        foundationPiles: [],
+        tableauPiles: [],
+      };
+      const layoutManager = new BoardLayoutManager(
+        scene as unknown as BoardScene,
+      );
+
+      layoutManager.createInitialLayout();
+      layoutManager.updateVisualLayout();
+
+      expect(scene.stockPile.position).toEqual({ x: 20, y: 20 });
+      expect({
+        x: stockSprite.x,
+        y: stockSprite.y,
+        scale: stockSprite.scale,
+      }).toEqual({ x: 25, y: 30, scale: 0.5 });
+    });
   });
 
-  it("defaults scale factor to 1.0 when viewport scale object is missing", () => {
-    const mockBoardScene = {
-      stockPile: { position: { x: 0, y: 0 } },
-      wastePile: { position: { x: 0, y: 0 } },
-      foundationPiles: [],
-      tableauPiles: [],
-    };
-    const layoutManager = new BoardLayoutManager(
-      mockBoardScene as unknown as BoardScene,
-    );
+  describe("getScaleFactor", () => {
+    function scaleFactorFor(scale?: { width: number; height: number }): number {
+      const scene = { scale } as unknown as BoardScene;
+      return new BoardLayoutManager(scene).getScaleFactor();
+    }
 
-    const scaleFactor = layoutManager.getScaleFactor();
+    it("defaults to 1.0 when the viewport scale is missing", () => {
+      expect(scaleFactorFor(undefined)).toBe(1.0);
+    });
 
-    expect(scaleFactor).toBe(1.0);
-  });
+    it("caps at 1.0 when the viewport is larger than the default", () => {
+      expect(scaleFactorFor({ width: 3000, height: 2000 })).toBe(1.0);
+    });
 
-  it("caps scale factor to 1.0 when viewport is larger than default", () => {
-    const mockBoardScene = {
-      scale: {
-        width: 3000,
-        height: 2000,
-      },
-    };
-    const layoutManager = new BoardLayoutManager(
-      mockBoardScene as unknown as BoardScene,
-    );
-
-    const scaleFactor = layoutManager.getScaleFactor();
-
-    expect(scaleFactor).toBe(1.0);
-  });
-
-  it("defaults scale factor to 1.0 when scale factor is <= 0", () => {
-    const mockBoardScene = {
-      scale: {
-        width: -10,
-        height: -20,
-      },
-    };
-    const layoutManager = new BoardLayoutManager(
-      mockBoardScene as unknown as BoardScene,
-    );
-
-    const scaleFactor = layoutManager.getScaleFactor();
-
-    expect(scaleFactor).toBe(1.0);
+    it("defaults to 1.0 when the computed scale is not positive", () => {
+      expect(scaleFactorFor({ width: -10, height: -20 })).toBe(1.0);
+    });
   });
 });

--- a/test/game/render/visual.spec.ts
+++ b/test/game/render/visual.spec.ts
@@ -1,190 +1,157 @@
 import { vi } from "vitest";
 import * as Phaser from "phaser";
 import { CardPile } from "@/game/model/card/card_pile";
-import { PlayingCard } from "@/game/model/card/playing_card";
 import { PlayingCardVisual } from "@/game/render/visual/card/playing_card_visual";
 import { StockPileVisual } from "@/game/render/visual/pile/stock_pile_visual";
 import { WastePileVisual } from "@/game/render/visual/pile/waste_pile_visual";
 import { FoundationPileVisual } from "@/game/render/visual/pile/foundation_pile_visual";
 import { TableauPileVisual } from "@/game/render/visual/pile/tableau_pile_visual";
 import { Visual } from "@/game/render/visual/visual";
+import { makePlayingCard } from "@test/support/card_builder";
 
-describe("Visual classes", () => {
-  describe("Visual Base Class", () => {
-    it("can set and get sprite", () => {
-      const visual = new Visual();
-      const mockSprite = {
-        setPosition: vi.fn(),
-      } as unknown as Phaser.GameObjects.Sprite;
-      visual.sprite = mockSprite;
-      expect(visual.sprite).toBe(mockSprite);
-    });
+/** Builds a card visual for a fresh card with the given id and face state. */
+function cardVisual(id: string, faceUp = false): PlayingCardVisual {
+  return new PlayingCardVisual(makePlayingCard({ id, faceUp }));
+}
+
+describe("Visual base class", () => {
+  it("exposes the sprite it was assigned", () => {
+    const visual = new Visual();
+    const sprite = {
+      setPosition: vi.fn(),
+    } as unknown as Phaser.GameObjects.Sprite;
+
+    visual.sprite = sprite;
+
+    expect(visual.sprite).toBe(sprite);
+  });
+});
+
+describe("PlayingCardVisual", () => {
+  it("is a Visual wrapping the given card, positioned at the origin", () => {
+    const card = makePlayingCard({ id: "c1" });
+
+    const visual = new PlayingCardVisual(card);
+
+    expect(visual).toBeInstanceOf(Visual);
+    expect(visual.value).toBe(card);
+    expect(visual.position).toEqual({ x: 0, y: 0 });
   });
 
-  describe("PlayingCardVisual", () => {
-    it("can be created and extends Visual", () => {
-      const playingCard = new PlayingCard();
-      playingCard.id = "c1";
+  it("exposes the position it was assigned", () => {
+    const visual = cardVisual("c1");
 
-      const visual = new PlayingCardVisual(playingCard);
+    visual.position = { x: 100, y: 200 };
 
-      expect(visual).toBeInstanceOf(Visual);
-      expect(visual.value).toBe(playingCard);
-      expect(visual.position).toEqual({ x: 0, y: 0 });
-    });
+    expect(visual.position).toEqual({ x: 100, y: 200 });
+  });
+});
 
-    it("can set and get position", () => {
-      const playingCard = new PlayingCard();
-      playingCard.id = "c1";
-      const visual = new PlayingCardVisual(playingCard);
+describe("StockPileVisual", () => {
+  it("is a Visual wrapping the given pile, positioned at the origin", () => {
+    const pile = new CardPile();
 
-      visual.position = { x: 100, y: 200 };
+    const visual = new StockPileVisual(pile);
 
-      expect(visual.position).toEqual({ x: 100, y: 200 });
-    });
+    expect(visual).toBeInstanceOf(Visual);
+    expect(visual.value).toBe(pile);
+    expect(visual.position).toEqual({ x: 0, y: 0 });
   });
 
-  describe("StockPileVisual", () => {
-    it("can be created and extends Visual", () => {
-      const cardPile = new CardPile();
+  it("stacks every card at the pile origin", () => {
+    const v1 = cardVisual("c1");
+    const v2 = cardVisual("c2");
+    const visual = new StockPileVisual(new CardPile(), [v1, v2]);
 
-      const visual = new StockPileVisual(cardPile);
+    visual.layoutPile();
 
-      expect(visual).toBeInstanceOf(Visual);
-      expect(visual.value).toBe(cardPile);
-      expect(visual.position).toEqual({ x: 0, y: 0 });
-    });
+    expect(v1.position).toEqual({ x: 0, y: 0 });
+    expect(v2.position).toEqual({ x: 0, y: 0 });
+  });
+});
 
-    it("can set and get position", () => {
-      const cardPile = new CardPile();
-      const visual = new StockPileVisual(cardPile);
+describe("WastePileVisual", () => {
+  it("is a Visual wrapping the given pile", () => {
+    const pile = new CardPile();
 
-      visual.position = { x: 50, y: 75 };
+    const visual = new WastePileVisual(pile);
 
-      expect(visual.position).toEqual({ x: 50, y: 75 });
-    });
-
-    it("lays out cards stacked on top of each other", () => {
-      const card1 = new PlayingCard();
-      card1.id = "c1";
-      const card2 = new PlayingCard();
-      card2.id = "c2";
-      const v1 = new PlayingCardVisual(card1);
-      const v2 = new PlayingCardVisual(card2);
-      const visual = new StockPileVisual(new CardPile(), [v1, v2]);
-
-      visual.layoutPile();
-      expect(v1.position).toEqual({ x: 0, y: 0 });
-      expect(v2.position).toEqual({ x: 0, y: 0 });
-    });
+    expect(visual).toBeInstanceOf(Visual);
+    expect(visual.value).toBe(pile);
   });
 
-  describe("WastePileVisual", () => {
-    it("can be created and extends Visual", () => {
-      const cardPile = new CardPile();
-      const visual = new WastePileVisual(cardPile);
+  it("fans the top cards out horizontally", () => {
+    const v1 = cardVisual("c1");
+    const v2 = cardVisual("c2");
+    const visual = new WastePileVisual(new CardPile(), [v1, v2]);
 
-      expect(visual).toBeInstanceOf(Visual);
-      expect(visual.value).toBe(cardPile);
-      expect(visual.position).toEqual({ x: 0, y: 0 });
-    });
+    visual.layoutPile();
 
-    it("fans out topmost cards horizontally", () => {
-      const card1 = new PlayingCard();
-      card1.id = "c1";
-      const card2 = new PlayingCard();
-      card2.id = "c2";
-      const v1 = new PlayingCardVisual(card1);
-      const v2 = new PlayingCardVisual(card2);
-      const visual = new WastePileVisual(new CardPile(), [v1, v2]);
-
-      visual.layoutPile();
-      expect(v1.position).toEqual({ x: 0, y: 0 });
-      expect(v2.position).toEqual({ x: 25, y: 0 });
-    });
-
-    it("stacks cards below the fan at the origin when cards count exceeds MAX_FAN_CARDS", () => {
-      const card1 = new PlayingCard();
-      card1.id = "c1";
-      const card2 = new PlayingCard();
-      card2.id = "c2";
-      const card3 = new PlayingCard();
-      card3.id = "c3";
-      const card4 = new PlayingCard();
-      card4.id = "c4";
-
-      const v1 = new PlayingCardVisual(card1);
-      const v2 = new PlayingCardVisual(card2);
-      const v3 = new PlayingCardVisual(card3);
-      const v4 = new PlayingCardVisual(card4);
-
-      const visual = new WastePileVisual(new CardPile(), [v1, v2, v3, v4]);
-      visual.layoutPile();
-
-      // Card 1 is below the fan (count = 4, MAX_FAN_CARDS = 3, fanStartIndex = 1)
-      expect(v1.position).toEqual({ x: 0, y: 0 });
-      // Card 2, 3, 4 are fanned
-      expect(v2.position).toEqual({ x: 0, y: 0 });
-      expect(v3.position).toEqual({ x: 25, y: 0 });
-      expect(v4.position).toEqual({ x: 50, y: 0 });
-    });
+    expect(v1.position).toEqual({ x: 0, y: 0 });
+    expect(v2.position).toEqual({ x: 25, y: 0 });
   });
 
-  describe("FoundationPileVisual", () => {
-    it("can be created and extends Visual", () => {
-      const cardPile = new CardPile();
-      const visual = new FoundationPileVisual(cardPile);
+  it("stacks overflow cards at the origin and fans only the last MAX_FAN_CARDS", () => {
+    const v1 = cardVisual("c1");
+    const v2 = cardVisual("c2");
+    const v3 = cardVisual("c3");
+    const v4 = cardVisual("c4");
+    const visual = new WastePileVisual(new CardPile(), [v1, v2, v3, v4]);
 
-      expect(visual).toBeInstanceOf(Visual);
-      expect(visual.value).toBe(cardPile);
-    });
+    visual.layoutPile();
 
-    it("lays out cards stacked on top of each other", () => {
-      const card1 = new PlayingCard();
-      card1.id = "c1";
-      const card2 = new PlayingCard();
-      card2.id = "c2";
-      const v1 = new PlayingCardVisual(card1);
-      const v2 = new PlayingCardVisual(card2);
-      const visual = new FoundationPileVisual(new CardPile(), [v1, v2]);
+    // With 4 cards (MAX_FAN_CARDS = 3) the first card sits below the fan at the
+    // origin and the last three are fanned.
+    expect(v1.position).toEqual({ x: 0, y: 0 });
+    expect(v2.position).toEqual({ x: 0, y: 0 });
+    expect(v3.position).toEqual({ x: 25, y: 0 });
+    expect(v4.position).toEqual({ x: 50, y: 0 });
+  });
+});
 
-      visual.layoutPile();
-      expect(v1.position).toEqual({ x: 0, y: 0 });
-      expect(v2.position).toEqual({ x: 0, y: 0 });
-    });
+describe("FoundationPileVisual", () => {
+  it("is a Visual wrapping the given pile", () => {
+    const pile = new CardPile();
+
+    const visual = new FoundationPileVisual(pile);
+
+    expect(visual).toBeInstanceOf(Visual);
+    expect(visual.value).toBe(pile);
   });
 
-  describe("TableauPileVisual", () => {
-    it("can be created and extends Visual", () => {
-      const cardPile = new CardPile();
-      const visual = new TableauPileVisual(cardPile);
+  it("stacks every card at the pile origin", () => {
+    const v1 = cardVisual("c1");
+    const v2 = cardVisual("c2");
+    const visual = new FoundationPileVisual(new CardPile(), [v1, v2]);
 
-      expect(visual).toBeInstanceOf(Visual);
-      expect(visual.value).toBe(cardPile);
-    });
+    visual.layoutPile();
 
-    it("fans out face-down cards closer together and face-up cards further apart", () => {
-      const card1 = new PlayingCard();
-      card1.id = "c1";
-      card1.faceUp = false;
-      const card2 = new PlayingCard();
-      card2.id = "c2";
-      card2.faceUp = true;
-      const card3 = new PlayingCard();
-      card3.id = "c3";
-      card3.faceUp = false;
+    expect(v1.position).toEqual({ x: 0, y: 0 });
+    expect(v2.position).toEqual({ x: 0, y: 0 });
+  });
+});
 
-      const v1 = new PlayingCardVisual(card1);
-      const v2 = new PlayingCardVisual(card2);
-      const v3 = new PlayingCardVisual(card3);
+describe("TableauPileVisual", () => {
+  it("is a Visual wrapping the given pile", () => {
+    const pile = new CardPile();
 
-      const visual = new TableauPileVisual(new CardPile(), [v1, v2, v3]);
+    const visual = new TableauPileVisual(pile);
 
-      visual.layoutPile();
-      // v1 is face-down => offset is 18px => v2 y is 18
-      expect(v2.position).toEqual({ x: 0, y: 18 });
-      // v2 is face-up => offset is 45px => v3 y is 18 + 45 = 63
-      expect(v3.position).toEqual({ x: 0, y: 63 });
-    });
+    expect(visual).toBeInstanceOf(Visual);
+    expect(visual.value).toBe(pile);
+  });
+
+  it("spaces face-down cards closer together than face-up cards", () => {
+    const v1 = cardVisual("c1", false);
+    const v2 = cardVisual("c2", true);
+    const v3 = cardVisual("c3", false);
+    const visual = new TableauPileVisual(new CardPile(), [v1, v2, v3]);
+
+    visual.layoutPile();
+
+    // v1 is face-down => 18px offset => v2 sits at y = 18.
+    expect(v2.position).toEqual({ x: 0, y: 18 });
+    // v2 is face-up => 45px offset => v3 sits at y = 18 + 45 = 63.
+    expect(v3.position).toEqual({ x: 0, y: 63 });
   });
 });

--- a/test/support/card_builder.ts
+++ b/test/support/card_builder.ts
@@ -1,0 +1,27 @@
+import { Card } from "@/game/model/card/card";
+import { PlayingCard, Suit, Type } from "@/game/model/card/playing_card";
+
+/**
+ * Builds a plain {@link Card} with sensible defaults. Pass overrides for the
+ * fields a test actually cares about so the intent of each test stays obvious.
+ */
+export function makeCard(overrides: Partial<Card> = {}): Card {
+  return { id: "card", faceUp: false, ...overrides };
+}
+
+/**
+ * Builds a {@link PlayingCard} with sensible defaults. Only the fields a test
+ * depends on need to be supplied via overrides.
+ */
+export function makePlayingCard(
+  overrides: Partial<
+    Pick<PlayingCard, "id" | "faceUp" | "suite" | "type">
+  > = {},
+): PlayingCard {
+  const card = new PlayingCard();
+  card.id = overrides.id ?? "card";
+  card.faceUp = overrides.faceUp ?? false;
+  card.suite = overrides.suite ?? Suit.SPADE;
+  card.type = overrides.type ?? Type.ACE;
+  return card;
+}

--- a/test/support/game_scenarios.ts
+++ b/test/support/game_scenarios.ts
@@ -1,0 +1,68 @@
+import { CardPile } from "@/game/model/card/card_pile";
+import {
+  ALL_PLAYING_CARD_IDS,
+  PlayingCard,
+} from "@/game/model/card/playing_card";
+import { SolitaireGame } from "@/game/model/game/solitaire_game";
+import { playingCardIdToFileName } from "@/game/render/asset/card_assets";
+
+/** Id of the only card left out of the foundations by {@link almostWon}. */
+export const CLUB_KING_ID = "card-clubs-king";
+
+/** Empties every pile on the board so a test can build an exact position. */
+export function emptyBoard(game: SolitaireGame): void {
+  game.stock.clear();
+  game.waste.clear();
+  game.tableaus.forEach((tableau) => tableau.clear());
+  game.foundations.forEach((foundation) => foundation.clear());
+}
+
+/**
+ * Moves the card with the given id out of whatever pile currently holds it and
+ * onto the target pile, returning the card. The game must already have been
+ * started so the card exists in the model.
+ */
+export function relocate(
+  game: SolitaireGame,
+  cardId: string,
+  targetPile: CardPile<PlayingCard>,
+  faceUp = true,
+): PlayingCard {
+  const card = game.getCardById(cardId)!;
+  game.getPileContainingCard(cardId)?.removeCard(card);
+  card.faceUp = faceUp;
+  targetPile.addCard(card);
+  return card;
+}
+
+/**
+ * Forces a waste-to-stock recycle: empties the stock, places a single card in
+ * the waste, and draws so the game recycles the waste back into the stock.
+ */
+export function forceWasteRecycle(
+  game: SolitaireGame,
+  card: PlayingCard,
+): void {
+  game.stock.clear();
+  game.waste.clear();
+  game.waste.addCard(card);
+  game.drawCardsFromStock();
+}
+
+/**
+ * Places 51 of the 52 cards face-up on their suit foundations, leaving only the
+ * King of Clubs out, so a single move can complete the game. The game must
+ * already have been started so the cards exist in the model.
+ */
+export function almostWon(game: SolitaireGame): void {
+  emptyBoard(game);
+  for (const cardId of ALL_PLAYING_CARD_IDS) {
+    const id = playingCardIdToFileName(cardId);
+    if (id === CLUB_KING_ID) {
+      continue;
+    }
+    const card = game.getCardById(id)!;
+    card.faceUp = true;
+    game.foundations[cardId.suit].addCard(card);
+  }
+}

--- a/test/support/phaser_mocks.ts
+++ b/test/support/phaser_mocks.ts
@@ -1,0 +1,257 @@
+import { vi, type Mock } from "vitest";
+import * as Phaser from "phaser";
+
+/** Shape of a shadow filter recorded by a mock sprite. */
+export interface ShadowConfig {
+  x: number;
+  y: number;
+  decay: number;
+  intensity: number;
+  color: number;
+  blur: number;
+  opacity: number;
+}
+
+/**
+ * A lightweight stand-in for a Phaser sprite. Setter methods record their
+ * effect on plain fields so tests can assert resulting state, and it registers
+ * and dispatches its own pointer listeners so tests can drive interaction with
+ * {@link MockSprite.emit} instead of reaching into mock call internals.
+ */
+export interface MockSprite {
+  x: number;
+  y: number;
+  alpha: number;
+  originX: number;
+  originY: number;
+  depth: number;
+  scale: number;
+  frame: string;
+  active: boolean;
+  displayWidth: number;
+  displayHeight: number;
+  input: { cursor: string } | null;
+  interactiveConfig: { useHandCursor: boolean } | null;
+  filtersEnabled: boolean;
+  shadowsAdded: ShadowConfig[];
+  filters: { external: { addShadow: (...args: number[]) => MockSprite } };
+  setOrigin(x: number, y: number): MockSprite;
+  setAlpha(alpha: number): MockSprite;
+  setInteractive(config?: { useHandCursor: boolean }): MockSprite;
+  enableFilters(): MockSprite;
+  setFrame(frame: string): MockSprite;
+  setPosition(x: number, y: number): MockSprite;
+  setScale(scale: number): MockSprite;
+  setDepth(depth: number): MockSprite;
+  setData(key: string, value: unknown): MockSprite;
+  getData(key: string): unknown;
+  on(event: string, callback: (...args: unknown[]) => void): MockSprite;
+  emit(event: string, ...args: unknown[]): void;
+}
+
+/** Overridable initial fields for a {@link MockSprite}. */
+export type MockSpriteOptions = Partial<
+  Pick<
+    MockSprite,
+    "x" | "y" | "frame" | "active" | "displayWidth" | "displayHeight"
+  >
+>;
+
+/** Builds a {@link MockSprite} with recording setters and its own listeners. */
+export function createMockSprite(options: MockSpriteOptions = {}): MockSprite {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  const data = new Map<string, unknown>();
+
+  const sprite: MockSprite = {
+    x: options.x ?? 0,
+    y: options.y ?? 0,
+    alpha: 1,
+    originX: 0,
+    originY: 0,
+    depth: 0,
+    scale: 1,
+    frame: options.frame ?? "",
+    active: options.active ?? true,
+    displayWidth: options.displayWidth ?? 220,
+    displayHeight: options.displayHeight ?? 307,
+    input: null,
+    interactiveConfig: null,
+    filtersEnabled: false,
+    shadowsAdded: [],
+    filters: {
+      external: {
+        addShadow(...args: number[]): MockSprite {
+          const [x, y, decay, intensity, color, blur, opacity] = args;
+          sprite.shadowsAdded.push({
+            x,
+            y,
+            decay,
+            intensity,
+            color,
+            blur,
+            opacity,
+          });
+          return sprite;
+        },
+      },
+    },
+    setOrigin(x: number, y: number): MockSprite {
+      sprite.originX = x;
+      sprite.originY = y;
+      return sprite;
+    },
+    setAlpha(alpha: number): MockSprite {
+      sprite.alpha = alpha;
+      return sprite;
+    },
+    setInteractive(config?: { useHandCursor: boolean }): MockSprite {
+      sprite.interactiveConfig = config ?? null;
+      sprite.input = { cursor: "default" };
+      return sprite;
+    },
+    enableFilters(): MockSprite {
+      sprite.filtersEnabled = true;
+      return sprite;
+    },
+    setFrame(frame: string): MockSprite {
+      sprite.frame = frame;
+      return sprite;
+    },
+    setPosition(x: number, y: number): MockSprite {
+      sprite.x = x;
+      sprite.y = y;
+      return sprite;
+    },
+    setScale(scale: number): MockSprite {
+      sprite.scale = scale;
+      return sprite;
+    },
+    setDepth(depth: number): MockSprite {
+      sprite.depth = depth;
+      return sprite;
+    },
+    setData(key: string, value: unknown): MockSprite {
+      data.set(key, value);
+      return sprite;
+    },
+    getData(key: string): unknown {
+      return data.get(key);
+    },
+    on(event: string, callback: (...args: unknown[]) => void): MockSprite {
+      const existing = listeners.get(event) ?? [];
+      existing.push(callback);
+      listeners.set(event, existing);
+      return sprite;
+    },
+    emit(event: string, ...args: unknown[]): void {
+      for (const callback of listeners.get(event) ?? []) {
+        callback(...args);
+      }
+    },
+  };
+
+  return sprite;
+}
+
+/** Casts a {@link MockSprite} to the Phaser sprite type expected by sources. */
+export function asSprite(sprite: MockSprite): Phaser.GameObjects.Sprite {
+  return sprite as unknown as Phaser.GameObjects.Sprite;
+}
+
+/** A mock Phaser Graphics object whose draw methods are spies. */
+export interface MockGraphics {
+  clear: Mock;
+  lineStyle: Mock;
+  strokeRect: Mock;
+  strokeRoundedRect: Mock;
+  setDepth: Mock;
+}
+
+/** Builds a {@link MockGraphics} whose chainable methods return itself. */
+export function createMockGraphics(): MockGraphics {
+  const graphics: MockGraphics = {
+    clear: vi.fn(() => graphics),
+    lineStyle: vi.fn(() => graphics),
+    strokeRect: vi.fn(() => graphics),
+    strokeRoundedRect: vi.fn(() => graphics),
+    setDepth: vi.fn(() => graphics),
+  };
+  return graphics;
+}
+
+/** A rectangle with the surface of Phaser.Geom.Rectangle used by sources. */
+export class MockRectangle {
+  constructor(
+    public x = 0,
+    public y = 0,
+    public width = 0,
+    public height = 0,
+  ) {}
+}
+
+/**
+ * Computes the intersection of two rectangles into `out`, matching the
+ * behavior of Phaser.Geom.Rectangle.Intersection.
+ */
+export function rectangleIntersection(
+  rect1: MockRectangle,
+  rect2: MockRectangle,
+  out: MockRectangle,
+): MockRectangle {
+  const left = Math.max(rect1.x, rect2.x);
+  const top = Math.max(rect1.y, rect2.y);
+  const right = Math.min(rect1.x + rect1.width, rect2.x + rect2.width);
+  const bottom = Math.min(rect1.y + rect1.height, rect2.y + rect2.height);
+
+  if (left >= right || top >= bottom) {
+    out.x = 0;
+    out.y = 0;
+    out.width = 0;
+    out.height = 0;
+  } else {
+    out.x = left;
+    out.y = top;
+    out.width = right - left;
+    out.height = bottom - top;
+  }
+  return out;
+}
+
+/**
+ * Returns a partial mock of the phaser module exposing only Geom.Rectangle,
+ * enough for sources that compute rectangle overlaps. Load it from an async
+ * `vi.mock("phaser", ...)` factory so the phaser module is not required at
+ * runtime in the node test environment.
+ */
+export function geomPhaserMock(): {
+  Geom: { Rectangle: typeof MockRectangle };
+} {
+  return {
+    Geom: {
+      Rectangle: Object.assign(MockRectangle, {
+        Intersection: rectangleIntersection,
+      }),
+    },
+  };
+}
+
+/** A mock Phaser input system that records and dispatches its listeners. */
+export interface MockInput {
+  on: Mock;
+  setDraggable: Mock;
+  emit(event: string, ...args: unknown[]): void;
+}
+
+/** Builds a {@link MockInput} so tests can drive drag events via emit. */
+export function createMockInput(): MockInput {
+  const listeners = new Map<string, (...args: unknown[]) => void>();
+  return {
+    on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+      listeners.set(event, callback);
+    }),
+    setDraggable: vi.fn(),
+    emit(event: string, ...args: unknown[]): void {
+      listeners.get(event)?.(...args);
+    },
+  };
+}

--- a/test/support/phaser_mocks.ts
+++ b/test/support/phaser_mocks.ts
@@ -255,3 +255,60 @@ export function createMockInput(): MockInput {
     },
   };
 }
+
+/** A mock Phaser scale manager that records and dispatches its listeners. */
+export interface MockScaleManager {
+  on: Mock;
+  emit(event: string, ...args: unknown[]): void;
+  width: number;
+  height: number;
+}
+
+/** Builds a {@link MockScaleManager} so tests can drive resize via emit. */
+export function createMockScaleManager(): MockScaleManager {
+  const listeners = new Map<string, (...args: unknown[]) => void>();
+  return {
+    on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+      listeners.set(event, callback);
+    }),
+    emit(event: string, ...args: unknown[]): void {
+      listeners.get(event)?.(...args);
+    },
+    width: 0,
+    height: 0,
+  };
+}
+
+/**
+ * Returns a mock of the phaser module suitable for exercising BoardScene: a
+ * Scene base class exposing recording add/scale/input members plus a
+ * Geom.Rectangle stand-in. Load it from an async `vi.mock("phaser", ...)`
+ * factory so the real phaser module is not required in the node environment.
+ */
+export function boardScenePhaserMock(): {
+  Scene: new (...args: unknown[]) => {
+    add: { graphics: () => MockGraphics; sprite: Mock };
+    scale: MockScaleManager;
+    input: MockInput;
+  };
+  Geom: { Rectangle: typeof MockRectangle };
+} {
+  return {
+    Scene: class MockScene {
+      add = {
+        graphics: () => createMockGraphics(),
+        sprite: vi.fn(
+          (x?: number, y?: number, _texture?: string, frame?: string) =>
+            createMockSprite({ x, y, frame }),
+        ),
+      };
+      scale = createMockScaleManager();
+      input = createMockInput();
+    },
+    Geom: {
+      Rectangle: Object.assign(MockRectangle, {
+        Intersection: rectangleIntersection,
+      }),
+    },
+  };
+}

--- a/test/support/sequence_random.ts
+++ b/test/support/sequence_random.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns a deterministic stand-in for Math.random that yields the provided
+ * values in order. Lets tests drive shuffles and other randomized logic
+ * without spying on the global Math.random.
+ */
+export function sequenceRandom(values: number[]): () => number {
+  let index = 0;
+  return () => {
+    const value = values[index] ?? 0;
+    index++;
+    return value;
+  };
+}

--- a/test/ui/app/app.component.spec.ts
+++ b/test/ui/app/app.component.spec.ts
@@ -5,6 +5,13 @@ import { BehaviorSubject } from "rxjs";
 import { AppComponent } from "@/ui/app/app.component";
 import { GAME_MODEL } from "@/ui/app/game-model.provider";
 
+/** Window augmented with the global the component reads for theming. */
+interface SolitaireWindow extends Window {
+  solitaire?: {
+    game: { scene: { getScene(key: string): unknown } };
+  };
+}
+
 /** Creates a mock gameModel with observable state/settings matching the real API. */
 function createMockGameModel(
   overrides: {
@@ -51,197 +58,174 @@ function createMockGameModel(
   };
 }
 
-describe("AppComponent (TestBed)", () => {
-  let component: AppComponent;
-  let fixture: ComponentFixture<AppComponent>;
-  let mockGameModel: ReturnType<typeof createMockGameModel>;
+type MockGameModel = ReturnType<typeof createMockGameModel>;
 
-  beforeEach(async () => {
+/** Configures the TestBed with the given model and creates the component. */
+async function buildComponent(model: MockGameModel): Promise<{
+  fixture: ComponentFixture<AppComponent>;
+  component: AppComponent;
+}> {
+  await TestBed.configureTestingModule({
+    imports: [AppComponent],
+    providers: [{ provide: GAME_MODEL, useValue: model }],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(AppComponent);
+  return { fixture, component: fixture.componentInstance };
+}
+
+describe("AppComponent", () => {
+  beforeEach(() => {
     vi.useFakeTimers();
-
-    mockGameModel = createMockGameModel();
-
-    await TestBed.configureTestingModule({
-      imports: [AppComponent],
-      providers: [{ provide: GAME_MODEL, useValue: mockGameModel }],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(AppComponent);
-    component = fixture.componentInstance;
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    delete (window as any).solitaire;
+    delete (window as SolitaireWindow).solitaire;
   });
 
-  it("should have correct initial values", () => {
-    expect(component.score()).toBe(0);
-    expect(component.moves()).toBe(0);
-    expect(component.timerText()).toBe("00:00");
-    expect(component.isGameWon()).toBe(false);
-    expect(component.drawCount()).toBe(3);
-    expect(component.cardBack()).toBe("card-back-blue");
-    expect(component.selectedTheme).toBe("green");
-    expect(component.showSettings).toBe(false);
-  });
+  describe("with the default game model", () => {
+    let component: AppComponent;
+    let fixture: ComponentFixture<AppComponent>;
+    let mockGameModel: MockGameModel;
 
-  it("should toggle showSettings when toggleSettings is called", () => {
-    expect(component.showSettings).toBe(false);
-    component.toggleSettings();
-    expect(component.showSettings).toBe(true);
-    component.toggleSettings();
-    expect(component.showSettings).toBe(false);
-  });
-
-  it("should read initial values from the injected game model", () => {
-    const model = createMockGameModel({
-      score: 42,
-      moves: 3,
-      drawCount: 3,
-      cardBackStyle: "card-back-blue",
+    beforeEach(async () => {
+      mockGameModel = createMockGameModel();
+      ({ fixture, component } = await buildComponent(mockGameModel));
     });
 
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-      imports: [AppComponent],
-      providers: [{ provide: GAME_MODEL, useValue: model }],
+    it("starts with zeroed metrics and default settings", () => {
+      expect(component.score()).toBe(0);
+      expect(component.moves()).toBe(0);
+      expect(component.timerText()).toBe("00:00");
+      expect(component.isGameWon()).toBe(false);
+      expect(component.drawCount()).toBe(3);
+      expect(component.cardBack()).toBe("card-back-blue");
     });
 
-    const f = TestBed.createComponent(AppComponent);
-    const c = f.componentInstance;
+    it("starts with the green theme and settings hidden", () => {
+      expect(component.selectedTheme).toBe("green");
+      expect(component.showSettings).toBe(false);
+    });
 
-    expect(c.score()).toBe(42);
-    expect(c.moves()).toBe(3);
+    it("toggles the settings panel", () => {
+      component.toggleSettings();
+
+      expect(component.showSettings).toBe(true);
+    });
+
+    it("restarts the game and resets the won state and timer", () => {
+      component.isGameWon.set(true);
+
+      component.restartGame();
+
+      expect(mockGameModel.startNewGame).toHaveBeenCalled();
+      expect(component.isGameWon()).toBe(false);
+      expect(component.timerText()).toBe("00:00");
+    });
+
+    it("starts a new game and resets the won state and timer", () => {
+      component.isGameWon.set(true);
+
+      component.startNewGame();
+
+      expect(mockGameModel.startNewGame).toHaveBeenCalled();
+      expect(component.isGameWon()).toBe(false);
+      expect(component.timerText()).toBe("00:00");
+    });
+
+    it("sets the draw mode and restarts the game", () => {
+      component.setDrawMode(1);
+
+      expect(mockGameModel.setDrawCount).toHaveBeenCalledWith(1);
+      expect(mockGameModel.startNewGame).toHaveBeenCalled();
+    });
+
+    it("sets the card back style on the game model", () => {
+      component.setCardBack("card-back-red");
+
+      expect(mockGameModel.setCardBackStyle).toHaveBeenCalledWith(
+        "card-back-red",
+      );
+    });
+
+    it("reflects observable state changes from the game model", () => {
+      mockGameModel.state.score$.next(100);
+      mockGameModel.state.moves$.next(12);
+      mockGameModel.settings.drawCount$.next(1);
+      mockGameModel.settings.cardBackStyle$.next("card-back-red");
+
+      expect(component.score()).toBe(100);
+      expect(component.moves()).toBe(12);
+      expect(component.drawCount()).toBe(1);
+      expect(component.cardBack()).toBe("card-back-red");
+    });
+
+    it("runs the timer once the first move is made", () => {
+      mockGameModel.state.moves$.next(1);
+      TestBed.flushEffects();
+
+      vi.advanceTimersByTime(5000);
+
+      expect(component.timerText()).toBe("00:05");
+      fixture.destroy();
+    });
   });
 
-  it("should restart game and reset state correctly", () => {
-    component.isGameWon.set(true);
+  describe("reading initial values from the model", () => {
+    it("seeds the score and moves from the injected model", async () => {
+      const model = createMockGameModel({ score: 42, moves: 3 });
 
-    component.restartGame();
+      const { component } = await buildComponent(model);
 
-    expect(mockGameModel.startNewGame).toHaveBeenCalled();
-    expect(component.isGameWon()).toBe(false);
-    expect(component.timerText()).toBe("00:00");
+      expect(component.score()).toBe(42);
+      expect(component.moves()).toBe(3);
+    });
   });
 
-  it("should start a new game and reset state correctly", () => {
-    component.isGameWon.set(true);
+  describe("theming", () => {
+    it("updates the theme and the board camera background", async () => {
+      const { component } = await buildComponent(createMockGameModel());
+      const camera = { setBackgroundColor: vi.fn() };
+      const getScene = vi.fn().mockReturnValue({ cameras: { main: camera } });
+      (window as SolitaireWindow).solitaire = { game: { scene: { getScene } } };
 
-    component.startNewGame();
+      component.setTheme("purple");
 
-    expect(mockGameModel.startNewGame).toHaveBeenCalled();
-    expect(component.isGameWon()).toBe(false);
-    expect(component.timerText()).toBe("00:00");
+      expect(component.selectedTheme).toBe("purple");
+      expect(getScene).toHaveBeenCalledWith("board-scene");
+      expect(camera.setBackgroundColor).toHaveBeenCalledWith("#3c096c");
+    });
   });
 
-  it("should set draw mode and restart the game", () => {
-    component.setDrawMode(1);
+  describe("when the game is won", () => {
+    let component: AppComponent;
+    let mockGameModel: MockGameModel;
+    let emitGameWon: () => void;
 
-    expect(mockGameModel.setDrawCount).toHaveBeenCalledWith(1);
-    expect(mockGameModel.startNewGame).toHaveBeenCalled();
-  });
-
-  it("should set card back style on gameModel", () => {
-    component.setCardBack("card-back-red");
-
-    expect(mockGameModel.setCardBackStyle).toHaveBeenCalledWith(
-      "card-back-red",
-    );
-  });
-
-  it("should update theme and cameras main color on setTheme", () => {
-    const mockCamera = {
-      setBackgroundColor: vi.fn(),
-    };
-    const mockBoardScene = {
-      cameras: {
-        main: mockCamera,
-      },
-    };
-    const mockGame = {
-      scene: {
-        getScene: vi.fn().mockReturnValue(mockBoardScene),
-      },
-    };
-
-    (window as any).solitaire = {
-      game: mockGame,
-    };
-
-    component.setTheme("purple");
-
-    expect(component.selectedTheme).toBe("purple");
-    expect(mockGame.scene.getScene).toHaveBeenCalledWith("board-scene");
-    expect(mockCamera.setBackgroundColor).toHaveBeenCalledWith("#3c096c");
-  });
-
-  it("should update metrics when observable state changes", () => {
-    // Push new values through BehaviorSubjects
-    mockGameModel.state.score$.next(100);
-    mockGameModel.state.moves$.next(12);
-    mockGameModel.settings.drawCount$.next(1);
-    mockGameModel.settings.cardBackStyle$.next("card-back-red");
-
-    expect(component.score()).toBe(100);
-    expect(component.moves()).toBe(12);
-    expect(component.drawCount()).toBe(1);
-    expect(component.cardBack()).toBe("card-back-red");
-  });
-
-  it("should start the timer when moves > 0 and timer is not running, and advance it correctly", () => {
-    expect(component.timerText()).toBe("00:00");
-
-    // Push moves > 0 to trigger timer start via effect
-    mockGameModel.state.moves$.next(1);
-
-    // Flush the effect
-    TestBed.flushEffects();
-
-    vi.advanceTimersByTime(5000);
-
-    expect(component.timerText()).toBe("00:05");
-
-    fixture.destroy();
-  });
-
-  it("should stop timer and set isGameWon to true when game-won is emitted", () => {
-    // The component listens to game-won via fromGameEvent → toSignal.
-    // The mock uses .on() to register the callback, so we capture it.
-    let gameWonCallback: Function = () => {};
-    mockGameModel.on = vi
-      .fn()
-      .mockImplementation((event: string, cb: Function) => {
+    beforeEach(async () => {
+      emitGameWon = () => {};
+      mockGameModel = createMockGameModel();
+      mockGameModel.on = vi.fn((event: string, callback: () => void) => {
         if (event === "game-won") {
-          gameWonCallback = cb;
+          emitGameWon = callback;
         }
       });
-
-    // Recreate the component so it registers with the new mock
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-      imports: [AppComponent],
-      providers: [{ provide: GAME_MODEL, useValue: mockGameModel }],
+      ({ component } = await buildComponent(mockGameModel));
     });
-    const f = TestBed.createComponent(AppComponent);
-    const c = f.componentInstance;
 
-    // Push moves > 0 to start the timer
-    mockGameModel.state.moves$.next(1);
-    TestBed.flushEffects();
+    it("stops the timer and marks the game won", () => {
+      mockGameModel.state.moves$.next(1);
+      TestBed.flushEffects();
+      vi.advanceTimersByTime(1000);
+      expect(component.timerText()).toBe("00:01");
 
-    vi.advanceTimersByTime(1000);
-    expect(c.timerText()).toBe("00:01");
-    expect(c.isGameWon()).toBe(false);
+      emitGameWon();
+      TestBed.flushEffects();
 
-    // Emit game-won
-    gameWonCallback(undefined);
-    TestBed.flushEffects();
-
-    expect(c.isGameWon()).toBe(true);
-
-    // Timer should be stopped
-    vi.advanceTimersByTime(5000);
-    expect(c.timerText()).toBe("00:01");
+      expect(component.isGameWon()).toBe(true);
+      vi.advanceTimersByTime(5000);
+      expect(component.timerText()).toBe("00:01");
+    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "./src",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@test/*": ["test/*"]
     },
     "strictPropertyInitialization": false,
     "noImplicitAny": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,8 +15,12 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
+    alias: [
+      {
+        find: /^@test\//,
+        replacement: path.resolve(__dirname, "./test") + "/",
+      },
+      { find: /^@\//, replacement: path.resolve(__dirname, "./src") + "/" },
+    ],
   },
 });


### PR DESCRIPTION
Refactors the whole test suite to follow the testing guidelines in `.gemini/AGENT.md` (inherited by `CLAUDE.md`). All 13 test files / 171 tests pass; lint and prettier are clean. Landed as five focused commits.

## Highlights by guideline

**Test via public API (no private access / test-only accessors)**
- Replaced the `createAndShuffleDeck` private-method spy with an injectable `cardIds` constructor param on `SolitaireGame`.
- Removed the five test-only "backward compatibility" getters/setters from `BoardScene` and their tautological tests.
- Moved invalid-suit/type coverage off the global `ALL_PLAYING_CARD_IDS` mutation hack onto the real unit (`playingCardIdToFileName`) in a new `card_assets.spec.ts`.

**Real objects > mocks / never mock the class under test**
- Dropped tests that mocked `getPileContainingCard` on the game itself; simplified `isCardInteractable` to remove the unreachable unknown-pile branch and removed the redundant `cardIndex === -1` guard.
- Render specs use the real `SolitaireGame` and drive interaction by emitting real pointer/drag events instead of digging callbacks out of `vi.fn().mock.calls`.

**State > interaction**
- Assertions now verify resulting state (recorded payloads, sprite position/depth/frame, model pile contents, manager fields) rather than "was called".

**Avoid `any` / single AAA / simple logic / helpers**
- Added `test/support/` (card builder, deterministic RNG, scenario helpers, typed `phaser_mocks`) behind a new `@test` alias, removing raw `any` and ~90-line inline phaser mocks duplicated across specs.
- Split multi-AAA mega-tests (Draw 1/Draw 3 recycle penalties, the layout-position sweep, the TestBed-recreating AppComponent tests) into focused cases.

## Source seams added
- `Deck.shuffle(random?)` — injectable RNG.
- `SolitaireGame(cardIds?)` — injectable deck source.
- Simplified `isCardInteractable` and removed a redundant guard (both former branches were provably unreachable via any public path).
- Removed test-only `BoardScene` accessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)